### PR TITLE
Have outer classes extend Recipe too

### DIFF
--- a/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
@@ -46,10 +46,7 @@ import javax.tools.JavaFileObject;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Writer;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
+import java.lang.reflect.*;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -233,7 +230,8 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
 
                     StringBuilder recipe = new StringBuilder();
                     String recipeName = templateFqn.substring(templateFqn.lastIndexOf('.') + 1);
-                    recipe.append("public final class " + recipeName + " extends Recipe {\n");
+                    String modifiers = classDecl.getModifiers().getFlags().stream().map(m -> m.toString()).collect(Collectors.joining(" "));
+                    recipe.append(modifiers + " class " + recipeName + " extends Recipe {\n");
                     recipe.append("\n");
                     recipe.append("    @Override\n");
                     recipe.append("    public String getDisplayName() {\n");
@@ -396,8 +394,7 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
 
 
                                 for (String r : recipes.values()) {
-                                    out.write(r.replaceAll("(?m)^(.+)$", "    $1")
-                                            .replace("public final class", "public static final class"));
+                                    out.write(r.replaceAll("(?m)^(.+)$", "    $1"));
                                     out.write('\n');
                                 }
                                 out.write("}\n");

--- a/src/test/resources/recipes/MultipleDereferencesRecipes.java
+++ b/src/test/resources/recipes/MultipleDereferencesRecipes.java
@@ -8,7 +8,29 @@ import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.template.Primitive;
 import org.openrewrite.java.tree.*;
 
-public final class MultipleDereferencesRecipes {
+import java.util.Arrays;
+import java.util.List;
+
+public final class MultipleDereferencesRecipes extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Refaster recipes for `foo.MultipleDereferences`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Refaster template recipes for `foo.MultipleDereferences`.";
+    }
+
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        return Arrays.asList(
+                new StringIsEmptyRecipe(),
+                new EqualsItselfRecipe()
+        );
+    }
     public static final class StringIsEmptyRecipe extends Recipe {
 
         @Override

--- a/src/test/resources/recipes/MultipleDereferencesRecipes.java
+++ b/src/test/resources/recipes/MultipleDereferencesRecipes.java
@@ -31,7 +31,7 @@ public final class MultipleDereferencesRecipes extends Recipe {
                 new EqualsItselfRecipe()
         );
     }
-    public static final class StringIsEmptyRecipe extends Recipe {
+    public static class StringIsEmptyRecipe extends Recipe {
 
         @Override
         public String getDisplayName() {
@@ -62,7 +62,7 @@ public final class MultipleDereferencesRecipes extends Recipe {
         }
     }
 
-    public static final class EqualsItselfRecipe extends Recipe {
+    public static class EqualsItselfRecipe extends Recipe {
 
         @Override
         public String getDisplayName() {

--- a/src/test/resources/recipes/ShouldAddImportsRecipes.java
+++ b/src/test/resources/recipes/ShouldAddImportsRecipes.java
@@ -8,9 +8,31 @@ import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.template.Primitive;
 import org.openrewrite.java.tree.*;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
-public final class ShouldAddImportsRecipes {
+public final class ShouldAddImportsRecipes extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Refaster recipes for `foo.ShouldAddImports`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Refaster template recipes for `foo.ShouldAddImports`.";
+    }
+
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        return Arrays.asList(
+                new StringValueOfRecipe(),
+                new ObjectsEqualsRecipe()
+        );
+    }
+
     public static final class StringValueOfRecipe extends Recipe {
 
         @Override

--- a/src/test/resources/recipes/ShouldAddImportsRecipes.java
+++ b/src/test/resources/recipes/ShouldAddImportsRecipes.java
@@ -33,7 +33,7 @@ public final class ShouldAddImportsRecipes extends Recipe {
         );
     }
 
-    public static final class StringValueOfRecipe extends Recipe {
+    public static class StringValueOfRecipe extends Recipe {
 
         @Override
         public String getDisplayName() {
@@ -65,7 +65,7 @@ public final class ShouldAddImportsRecipes extends Recipe {
         }
     }
 
-    public static final class ObjectsEqualsRecipe extends Recipe {
+    public static class ObjectsEqualsRecipe extends Recipe {
 
         @Override
         public String getDisplayName() {

--- a/src/test/resources/recipes/ShouldSupportNestedClasses.java
+++ b/src/test/resources/recipes/ShouldSupportNestedClasses.java
@@ -15,4 +15,17 @@ public class ShouldSupportNestedClasses {
             return !s.isEmpty();
         }
     }
+
+    static class AnotherClass {
+        @BeforeTemplate
+        boolean before(String s) {
+            return s.length() == 0;
+        }
+
+        @AfterTemplate
+        boolean after(String s) {
+            return s.isEmpty();
+        }
+    }
+
 }

--- a/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
+++ b/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
@@ -26,11 +26,12 @@ public final class ShouldSupportNestedClassesRecipes extends Recipe {
     @Override
     public List<Recipe> getRecipeList() {
         return Arrays.asList(
-                new NestedClassRecipe()
+                new NestedClassRecipe(),
+                new AnotherClassRecipe()
         );
     }
 
-    public static final class NestedClassRecipe extends Recipe {
+    public static class NestedClassRecipe extends Recipe {
 
         @Override
         public String getDisplayName() {
@@ -47,6 +48,37 @@ public final class ShouldSupportNestedClassesRecipes extends Recipe {
             return new JavaVisitor<ExecutionContext>() {
                 final JavaTemplate before = JavaTemplate.compile(this, "before", (String s) -> s.length() > 0).build();
                 final JavaTemplate after = JavaTemplate.compile(this, "after", (String s) -> !s.isEmpty()).build();
+
+                @Override
+                public J visitBinary(J.Binary elem, ExecutionContext ctx) {
+                    JavaTemplate.Matcher matcher;
+                    if ((matcher = before.matcher(getCursor())).find()) {
+                        return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
+                    }
+                    return super.visitBinary(elem, ctx);
+                }
+
+            };
+        }
+    }
+
+    static class AnotherClassRecipe extends Recipe {
+
+        @Override
+        public String getDisplayName() {
+            return "Refaster template `ShouldSupportNestedClasses.AnotherClass`";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Recipe created for the following Refaster template:\n```java\nstatic class AnotherClass {\n    \n    @BeforeTemplate()\n    boolean before(String s) {\n        return s.length() == 0;\n    }\n    \n    @AfterTemplate()\n    boolean after(String s) {\n        return s.isEmpty();\n    }\n}\n```\n.";
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor() {
+            return new JavaVisitor<ExecutionContext>() {
+                final JavaTemplate before = JavaTemplate.compile(this, "before", (String s) -> s.length() == 0).build();
+                final JavaTemplate after = JavaTemplate.compile(this, "after", (JavaTemplate.F1<?, ?>) (String s) -> s.isEmpty()).build();
 
                 @Override
                 public J visitBinary(J.Binary elem, ExecutionContext ctx) {

--- a/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
+++ b/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
@@ -8,7 +8,28 @@ import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.template.Primitive;
 import org.openrewrite.java.tree.*;
 
-public final class ShouldSupportNestedClassesRecipes {
+import java.util.Arrays;
+import java.util.List;
+
+public final class ShouldSupportNestedClassesRecipes extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Refaster recipes for `foo.ShouldSupportNestedClasses`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Refaster template recipes for `foo.ShouldSupportNestedClasses`.";
+    }
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        return Arrays.asList(
+                new NestedClassRecipe()
+        );
+    }
+
     public static final class NestedClassRecipe extends Recipe {
 
         @Override

--- a/src/test/resources/recipes/UseStringIsEmptyRecipe.java
+++ b/src/test/resources/recipes/UseStringIsEmptyRecipe.java
@@ -8,7 +8,7 @@ import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.template.Primitive;
 import org.openrewrite.java.tree.*;
 
-public final class UseStringIsEmptyRecipe extends Recipe {
+public class UseStringIsEmptyRecipe extends Recipe {
 
     @Override
     public String getDisplayName() {


### PR DESCRIPTION
Simplifies calling related recipes all together without Yaml recipe lists.

I don't immediately see any possible negative effects: we already generate the class, and having a way to run all of them together should simplify things for the majority of cases.