### PR TITLE
Call ShortenFullyQualifiedTypeReferences after visit

### DIFF
--- a/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
@@ -314,6 +314,7 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
                                 recipe.append("                    maybeAddImport(\"" + import_.substring(0, dot) + "\", \"" + import_.substring(dot + 1) + "\");\n");
                             }
                         }
+                        recipe.append("                doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());\n");
                         if (parameters.isEmpty()) {
                             recipe.append("                    return " + after + ".apply(getCursor(), elem.getCoordinates().replace());\n");
                         } else {
@@ -343,6 +344,7 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
                             out.write("import org.openrewrite.TreeVisitor;\n");
                             out.write("import org.openrewrite.java.JavaTemplate;\n");
                             out.write("import org.openrewrite.java.JavaVisitor;\n");
+                            out.write("import org.openrewrite.java.ShortenFullyQualifiedTypeReferences;\n");
                             out.write("import org.openrewrite.java.template.Primitive;\n");
                             out.write("import org.openrewrite.java.tree.*;\n");
                             out.write("\n");

--- a/src/test/resources/recipes/MultipleDereferencesRecipes.java
+++ b/src/test/resources/recipes/MultipleDereferencesRecipes.java
@@ -5,6 +5,7 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.ShortenFullyQualifiedTypeReferences;
 import org.openrewrite.java.template.Primitive;
 import org.openrewrite.java.tree.*;
 
@@ -31,6 +32,7 @@ public final class MultipleDereferencesRecipes {
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
+                        doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(0));
                     }
                     return super.visitMethodInvocation(elem, ctx);
@@ -62,6 +64,7 @@ public final class MultipleDereferencesRecipes {
                 public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
+                        doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace());
                     }
                     return super.visitBinary(elem, ctx);

--- a/src/test/resources/recipes/ShouldAddImportsRecipes.java
+++ b/src/test/resources/recipes/ShouldAddImportsRecipes.java
@@ -5,6 +5,7 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.ShortenFullyQualifiedTypeReferences;
 import org.openrewrite.java.template.Primitive;
 import org.openrewrite.java.tree.*;
 
@@ -34,6 +35,7 @@ public final class ShouldAddImportsRecipes {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
                         maybeAddImport("java.util.Objects");
+                        doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                     }
                     return super.visitMethodInvocation(elem, ctx);
@@ -66,6 +68,7 @@ public final class ShouldAddImportsRecipes {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
                         maybeRemoveImport("java.util.Objects");
+                        doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1));
                     }
                     return super.visitMethodInvocation(elem, ctx);

--- a/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
+++ b/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
@@ -1,4 +1,3 @@
-
 package foo;
 
 import org.openrewrite.ExecutionContext;

--- a/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
+++ b/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
@@ -5,6 +5,7 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.ShortenFullyQualifiedTypeReferences;
 import org.openrewrite.java.template.Primitive;
 import org.openrewrite.java.tree.*;
 
@@ -31,6 +32,7 @@ public final class ShouldSupportNestedClassesRecipes {
                 public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
+                        doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                     }
                     return super.visitBinary(elem, ctx);

--- a/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
+++ b/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
@@ -1,3 +1,4 @@
+
 package foo;
 
 import org.openrewrite.ExecutionContext;
@@ -86,6 +87,7 @@ public final class ShouldSupportNestedClassesRecipes extends Recipe {
                 public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
+                        doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                     }
                     return super.visitBinary(elem, ctx);

--- a/src/test/resources/recipes/UseStringIsEmptyRecipe.java
+++ b/src/test/resources/recipes/UseStringIsEmptyRecipe.java
@@ -5,6 +5,7 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.ShortenFullyQualifiedTypeReferences;
 import org.openrewrite.java.template.Primitive;
 import org.openrewrite.java.tree.*;
 
@@ -30,6 +31,7 @@ public final class UseStringIsEmptyRecipe extends Recipe {
             public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
                 if ((matcher = before.matcher(getCursor())).find()) {
+                    doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
                     return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                 }
                 return super.visitBinary(elem, ctx);


### PR DESCRIPTION
## What's changed?
We now call `doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor())` from within the if statement.

## What's your motivation?
I _think_ this is what we discussed, such that templates can use fully qualified references for convenience, yet insert shortened references in practice.

## Anything in particular you'd like reviewers to focus on?
Did you indeed intend to call the visitor like this, or in a more targeted way?

## Anyone you would like to review specifically?
@knutwannheden 

## Have you considered any alternatives or workarounds?
Not sure if there's any other ways we might want to explore.

## Any additional context
This ought to help PRs such as this on
- https://github.com/openrewrite/rewrite-migrate-java/pull/272