### PR TITLE
Generate classpath entries for FQN references

### DIFF
--- a/src/main/java/org/openrewrite/java/template/TemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/TemplateProcessor.java
@@ -262,7 +262,7 @@ public class TemplateProcessor extends AbstractProcessor {
                                 out.write("                .builder(\"" + templateSource + "\")");
 
                                 List<Symbol> imports = ImportDetector.imports(resolved.get(template));
-                                String classpath = ClasspathJarNameDetector.classpathJarNames(resolved.get(template));
+                                String classpath = ClasspathJarNameDetector.classpathFor(resolved.get(template), imports);
                                 if (!classpath.isEmpty()) {
                                     out.write("\n                .javaParser(JavaParser.fromJavaVersion().classpath(" +
                                               classpath + "))");

--- a/src/main/java/org/openrewrite/java/template/TemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/TemplateProcessor.java
@@ -266,7 +266,7 @@ public class TemplateProcessor extends AbstractProcessor {
                                 out.write("                .builder(\"" + templateSource + "\")");
 
                                 List<Symbol> imports = ImportDetector.imports(resolved.get(template));
-                                for (Symbol anImport : imports) {
+                                for (Symbol anImport : imports) { // FIXME FQN also needs to be added to the parser classpath
                                     Symbol.ClassSymbol enclClass = anImport instanceof Symbol.ClassSymbol ? (Symbol.ClassSymbol) anImport : anImport.enclClass();
                                     while (enclClass.enclClass() != null && enclClass.enclClass() != enclClass) {
                                         enclClass = enclClass.enclClass();

--- a/src/main/java/org/openrewrite/java/template/internal/ClasspathJarNameDetector.java
+++ b/src/main/java/org/openrewrite/java/template/internal/ClasspathJarNameDetector.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.template.internal;
+
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
+import com.sun.tools.javac.tree.JCTree.JCIdent;
+import com.sun.tools.javac.tree.TreeScanner;
+
+import javax.lang.model.element.ElementKind;
+import javax.tools.JavaFileObject;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class ClasspathJarNameDetector {
+
+    /**
+     * Locate types that are directly referred to by name in the
+     * given tree and therefore need an import in the template.
+     *
+     * @return The list of imports to add.
+     */
+    public static String classpathJarNames(JCTree input) {
+        Set<String> jarNames = new LinkedHashSet<>();
+
+        new TreeScanner() {
+            @Override
+            public void scan(JCTree tree) {
+                JCTree maybeFieldAccess = tree;
+                if (maybeFieldAccess instanceof JCFieldAccess &&
+                    ((JCFieldAccess) maybeFieldAccess).sym instanceof Symbol.ClassSymbol &&
+                    Character.isUpperCase(((JCFieldAccess) maybeFieldAccess).getIdentifier().toString().charAt(0))) {
+                    while (maybeFieldAccess instanceof JCFieldAccess) {
+                        maybeFieldAccess = ((JCFieldAccess) maybeFieldAccess).getExpression();
+                        if (maybeFieldAccess instanceof JCIdent &&
+                            Character.isUpperCase(((JCIdent) maybeFieldAccess).getName().toString().charAt(0))) {
+                            // this might be a fully qualified type name, so we don't want to add an import for it
+                            // and returning will skip the nested identifier which represents just the class simple name
+                            return;
+                        }
+                    }
+                }
+
+                if (tree instanceof JCIdent) {
+                    if (tree.type == null || !(tree.type.tsym instanceof Symbol.ClassSymbol)) {
+                        return;
+                    }
+                    if (((JCIdent) tree).sym.getKind() == ElementKind.CLASS || ((JCIdent) tree).sym.getKind() == ElementKind.INTERFACE) {
+                        jarNames.add(jarNameFor(tree.type.tsym));
+                    } else if (((JCIdent) tree).sym.getKind() == ElementKind.FIELD) {
+                        jarNames.add(jarNameFor(((JCIdent) tree).sym));
+                    } else if (((JCIdent) tree).sym.getKind() == ElementKind.METHOD) {
+                        jarNames.add(jarNameFor(((JCIdent) tree).sym));
+                    } else if (((JCIdent) tree).sym.getKind() == ElementKind.ENUM_CONSTANT) {
+                        jarNames.add(jarNameFor(((JCIdent) tree).sym));
+                    }
+                } else if (tree instanceof JCFieldAccess && ((JCFieldAccess) tree).sym instanceof Symbol.VarSymbol
+                           && ((JCFieldAccess) tree).selected instanceof JCIdent
+                           && ((JCIdent) ((JCFieldAccess) tree).selected).sym instanceof Symbol.ClassSymbol) {
+                    jarNames.add(jarNameFor(((JCIdent) ((JCFieldAccess) tree).selected).sym));
+                } else if (tree instanceof JCFieldAccess && ((JCFieldAccess) tree).sym instanceof Symbol.MethodSymbol
+                           && ((JCFieldAccess) tree).selected instanceof JCIdent
+                           && ((JCIdent) ((JCFieldAccess) tree).selected).sym instanceof Symbol.ClassSymbol) {
+                    jarNames.add(jarNameFor(((JCIdent) ((JCFieldAccess) tree).selected).sym));
+                } else if (tree instanceof JCFieldAccess && ((JCFieldAccess) tree).sym instanceof Symbol.ClassSymbol
+                           && ((JCFieldAccess) tree).selected instanceof JCIdent
+                           && ((JCIdent) ((JCFieldAccess) tree).selected).sym instanceof Symbol.ClassSymbol
+                           && !(((JCIdent) ((JCFieldAccess) tree).selected).sym.type instanceof Type.ErrorType)) {
+                    jarNames.add(jarNameFor(((JCIdent) ((JCFieldAccess) tree).selected).sym));
+                }
+
+                super.scan(tree);
+            }
+        }.scan(input);
+
+        return jarNames.stream()
+                .filter(Objects::nonNull)
+                .map(jarName -> '"' + jarName + '"')
+                .collect(Collectors.joining(", "));
+    }
+
+
+    private static String jarNameFor(Symbol anImport) {
+        Symbol.ClassSymbol enclClass = anImport instanceof Symbol.ClassSymbol ? (Symbol.ClassSymbol) anImport : anImport.enclClass();
+        while (enclClass.enclClass() != null && enclClass.enclClass() != enclClass) {
+            enclClass = enclClass.enclClass();
+        }
+        JavaFileObject classfile = enclClass.classfile;
+        if (classfile != null) {
+            String uriStr = classfile.toUri().toString();
+            Matcher matcher = Pattern.compile("([^/]*)?\\.jar!/").matcher(uriStr);
+            if (matcher.find()) {
+                String jarName = matcher.group(1);
+                return jarName.replaceAll("-\\d.*$", "");
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/openrewrite/java/template/internal/ClasspathJarNameDetector.java
+++ b/src/main/java/org/openrewrite/java/template/internal/ClasspathJarNameDetector.java
@@ -53,7 +53,7 @@ public class ClasspathJarNameDetector {
                             Character.isUpperCase(((JCIdent) maybeFieldAccess).getName().toString().charAt(0))) {
                             // this might be a fully qualified type name, so we don't want to add an import for it
                             // and returning will skip the nested identifier which represents just the class simple name
-                            return;
+                            ;//return;
                         }
                     }
                 }

--- a/src/main/java/org/openrewrite/java/template/internal/ClasspathJarNameDetector.java
+++ b/src/main/java/org/openrewrite/java/template/internal/ClasspathJarNameDetector.java
@@ -21,7 +21,10 @@ import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
 import com.sun.tools.javac.tree.TreeScanner;
 
 import javax.tools.JavaFileObject;
-import java.util.*;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -35,7 +38,7 @@ public class ClasspathJarNameDetector {
      * @return The list of imports to add.
      */
     public static String classpathFor(JCTree input, List<Symbol> imports) {
-        Set<String> jarNames = new TreeSet<>();
+        Set<String> jarNames = new LinkedHashSet<>();
 
         for (Symbol anImport : imports) {
             jarNames.add(jarNameFor(anImport));
@@ -57,6 +60,7 @@ public class ClasspathJarNameDetector {
         return jarNames.stream()
                 .filter(Objects::nonNull)
                 .map(jarName -> '"' + jarName + '"')
+                .sorted()
                 .collect(Collectors.joining(", "));
     }
 

--- a/src/main/java/org/openrewrite/java/template/internal/ClasspathJarNameDetector.java
+++ b/src/main/java/org/openrewrite/java/template/internal/ClasspathJarNameDetector.java
@@ -21,10 +21,7 @@ import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
 import com.sun.tools.javac.tree.TreeScanner;
 
 import javax.tools.JavaFileObject;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -38,7 +35,7 @@ public class ClasspathJarNameDetector {
      * @return The list of imports to add.
      */
     public static String classpathFor(JCTree input, List<Symbol> imports) {
-        Set<String> jarNames = new LinkedHashSet<>();
+        Set<String> jarNames = new TreeSet<>();
 
         for (Symbol anImport : imports) {
             jarNames.add(jarNameFor(anImport));

--- a/src/test/java/org/openrewrite/java/template/TemplateProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/template/TemplateProcessorTest.java
@@ -20,7 +20,8 @@ import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.net.URL;
@@ -32,8 +33,12 @@ import static com.google.testing.compile.Compiler.javac;
 
 class TemplateProcessorTest {
 
-    @Test    
-    void generateRecipeTemplates() {
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "Unqualified",
+      "FullyQualified",
+    })
+    void generateRecipeTemplates(String qualifier) {
         // As per https://github.com/google/compile-testing/blob/v0.21.0/src/main/java/com/google/testing/compile/package-info.java#L53-L55
         Compilation compilation = javac()
           .withProcessors(new RefasterTemplateProcessor(), new TemplateProcessor())
@@ -42,11 +47,11 @@ class TemplateProcessorTest {
         assertThat(compilation).succeeded();
         compilation.generatedSourceFiles().forEach(System.out::println);
         assertThat(compilation)
-          .generatedSourceFile("foo/ShouldAddClasspathRecipe$1_before")
-          .hasSourceEquivalentTo(JavaFileObjects.forResource("recipes/ShouldAddClasspathRecipe$1_before.java"));
+          .generatedSourceFile("foo/ShouldAddClasspathRecipes$" + qualifier + "Recipe$1_before")
+          .hasSourceEquivalentTo(JavaFileObjects.forResource("recipes/ShouldAddClasspathRecipe$" + qualifier + "Recipe$1_before.java"));
         assertThat(compilation)
-          .generatedSourceFile("foo/ShouldAddClasspathRecipe$1_after")
-          .hasSourceEquivalentTo(JavaFileObjects.forResource("recipes/ShouldAddClasspathRecipe$1_after.java"));
+          .generatedSourceFile("foo/ShouldAddClasspathRecipes$" + qualifier + "Recipe$1_after")
+          .hasSourceEquivalentTo(JavaFileObjects.forResource("recipes/ShouldAddClasspathRecipe$" + qualifier + "Recipe$1_after.java"));
     }
 
     @NotNull

--- a/src/test/resources/recipes/ShouldAddClasspath.java
+++ b/src/test/resources/recipes/ShouldAddClasspath.java
@@ -14,7 +14,7 @@ public class ShouldAddClasspath {
 
         @AfterTemplate
         void after(String message) {
-            LoggerFactory.getLogger("ROOT").info(message);
+            LoggerFactory.getLogger(message);
         }
     }
 
@@ -26,7 +26,7 @@ public class ShouldAddClasspath {
 
         @AfterTemplate
         void after(String message) {
-            org.slf4j.LoggerFactory.getLogger("ROOT").info(message);
+            org.slf4j.LoggerFactory.getLogger(message);
         }
     }
 

--- a/src/test/resources/recipes/ShouldAddClasspath.java
+++ b/src/test/resources/recipes/ShouldAddClasspath.java
@@ -6,14 +6,28 @@ import org.slf4j.LoggerFactory;
 
 public class ShouldAddClasspath {
 
-    @BeforeTemplate
-    void before(String message) {
-        System.out.println(message);
+    class Unqualified {
+        @BeforeTemplate
+        void before(String message) {
+            System.out.println(message);
+        }
+
+        @AfterTemplate
+        void after(String message) {
+            LoggerFactory.getLogger("ROOT").info(message);
+        }
     }
 
-    @AfterTemplate
-    void after(String message) {
-        LoggerFactory.getLogger("ROOT").info(message);
+    class FullyQualified {
+        @BeforeTemplate
+        void before(String message) {
+            System.out.println(message);
+        }
+
+        @AfterTemplate
+        void after(String message) {
+            org.slf4j.LoggerFactory.getLogger("ROOT").info(message);
+        }
     }
 
 }

--- a/src/test/resources/recipes/ShouldAddClasspathRecipe$FullyQualifiedRecipe$1_after.java
+++ b/src/test/resources/recipes/ShouldAddClasspathRecipe$FullyQualifiedRecipe$1_after.java
@@ -1,0 +1,11 @@
+package foo;
+import org.openrewrite.java.*;
+
+public class ShouldAddClasspathRecipes$FullyQualifiedRecipe$1_after {
+    public static JavaTemplate.Builder getTemplate(JavaVisitor<?> visitor) {
+        return JavaTemplate
+                .builder("LoggerFactory.getLogger(\"ROOT\").inf#{any(java.lang.String)}ge)")
+                .javaParser(JavaParser.fromJavaVersion().classpath("slf4j-api"))
+                .imports("org.slf4j.LoggerFactory");
+    }
+}

--- a/src/test/resources/recipes/ShouldAddClasspathRecipe$FullyQualifiedRecipe$1_after.java
+++ b/src/test/resources/recipes/ShouldAddClasspathRecipe$FullyQualifiedRecipe$1_after.java
@@ -4,8 +4,7 @@ import org.openrewrite.java.*;
 public class ShouldAddClasspathRecipes$FullyQualifiedRecipe$1_after {
     public static JavaTemplate.Builder getTemplate(JavaVisitor<?> visitor) {
         return JavaTemplate
-                .builder("LoggerFactory.getLogger(\"ROOT\").inf#{any(java.lang.String)}ge)")
-                .javaParser(JavaParser.fromJavaVersion().classpath("slf4j-api"))
-                .imports("org.slf4j.LoggerFactory");
+                .builder("org.slf4j.LoggerFactory.getLogger(\"ROOT\").info(#{any(java.lang.String)}))")
+                .javaParser(JavaParser.fromJavaVersion().classpath("slf4j-api"));
     }
 }

--- a/src/test/resources/recipes/ShouldAddClasspathRecipe$FullyQualifiedRecipe$1_after.java
+++ b/src/test/resources/recipes/ShouldAddClasspathRecipe$FullyQualifiedRecipe$1_after.java
@@ -4,7 +4,7 @@ import org.openrewrite.java.*;
 public class ShouldAddClasspathRecipes$FullyQualifiedRecipe$1_after {
     public static JavaTemplate.Builder getTemplate(JavaVisitor<?> visitor) {
         return JavaTemplate
-                .builder("org.slf4j.LoggerFactory.getLogger(\"ROOT\").info(#{any(java.lang.String)}))")
+                .builder("org.slf4j.LoggerFactory.getLogger(#{any(java.lang.String)})")
                 .javaParser(JavaParser.fromJavaVersion().classpath("slf4j-api"));
     }
 }

--- a/src/test/resources/recipes/ShouldAddClasspathRecipe$FullyQualifiedRecipe$1_before.java
+++ b/src/test/resources/recipes/ShouldAddClasspathRecipe$FullyQualifiedRecipe$1_before.java
@@ -1,7 +1,7 @@
 package foo;
 import org.openrewrite.java.*;
 
-public class ShouldAddClasspathRecipe$1_before {
+public class ShouldAddClasspathRecipes$FullyQualifiedRecipe$1_before {
     public static JavaTemplate.Builder getTemplate(JavaVisitor<?> visitor) {
         return JavaTemplate
                 .builder("System.out.println(#{any(java.lang.String)})");

--- a/src/test/resources/recipes/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_after.java
+++ b/src/test/resources/recipes/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_after.java
@@ -4,7 +4,7 @@ import org.openrewrite.java.*;
 public class ShouldAddClasspathRecipes$UnqualifiedRecipe$1_after {
     public static JavaTemplate.Builder getTemplate(JavaVisitor<?> visitor) {
         return JavaTemplate
-                .builder("LoggerFactory.getLogger(\"ROOT\").inf#{any(java.lang.String)}ge)")
+                .builder("LoggerFactory.getLogger(\"ROOT\").info(#{any(java.lang.String)}))")
                 .javaParser(JavaParser.fromJavaVersion().classpath("slf4j-api"))
                 .imports("org.slf4j.LoggerFactory");
     }

--- a/src/test/resources/recipes/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_after.java
+++ b/src/test/resources/recipes/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_after.java
@@ -1,7 +1,7 @@
 package foo;
 import org.openrewrite.java.*;
 
-public class ShouldAddClasspathRecipe$1_after {
+public class ShouldAddClasspathRecipes$UnqualifiedRecipe$1_after {
     public static JavaTemplate.Builder getTemplate(JavaVisitor<?> visitor) {
         return JavaTemplate
                 .builder("LoggerFactory.getLogger(\"ROOT\").inf#{any(java.lang.String)}ge)")

--- a/src/test/resources/recipes/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_after.java
+++ b/src/test/resources/recipes/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_after.java
@@ -4,7 +4,7 @@ import org.openrewrite.java.*;
 public class ShouldAddClasspathRecipes$UnqualifiedRecipe$1_after {
     public static JavaTemplate.Builder getTemplate(JavaVisitor<?> visitor) {
         return JavaTemplate
-                .builder("LoggerFactory.getLogger(\"ROOT\").info(#{any(java.lang.String)}))")
+                .builder("LoggerFactory.getLogger(#{any(java.lang.String)})")
                 .javaParser(JavaParser.fromJavaVersion().classpath("slf4j-api"))
                 .imports("org.slf4j.LoggerFactory");
     }

--- a/src/test/resources/recipes/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_before.java
+++ b/src/test/resources/recipes/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_before.java
@@ -1,0 +1,9 @@
+package foo;
+import org.openrewrite.java.*;
+
+public class ShouldAddClasspathRecipes$UnqualifiedRecipe$1_before {
+    public static JavaTemplate.Builder getTemplate(JavaVisitor<?> visitor) {
+        return JavaTemplate
+                .builder("System.out.println(#{any(java.lang.String)})");
+    }
+}


### PR DESCRIPTION
## What's changed?
Right now fully qualified references do not generate classpath entries on the JavaTemplate classes, since we only loop over imports to generate those. We expand that to include any type use of classes that need imports.

## What's your motivation?
When we want to [swap between similar classes](https://github.com/openrewrite/rewrite-migrate-java/pull/272) we would want to use FQNs in the recipes for readability.

<!-- 
## Anything in particular you'd like reviewers to focus on?
You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

<!-- 
## Anyone you would like to review specifically?
@mention them here -->

<!-- 
## Have you considered any alternatives or workarounds?
Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
- https://github.com/openrewrite/rewrite-migrate-java/pull/272
- https://github.com/openrewrite/rewrite-templating/pull/18
