### PR TITLE
Add `doAfterVisit(UnnecessaryParentheses)` to generated recipes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     // Needed for annotation processing tests
     testImplementation(files(tools))
     testImplementation("org.openrewrite:rewrite-java:latest.integration")
+    testImplementation("org.openrewrite.recipe:rewrite-static-analysis:latest.integration")
     testImplementation("org.slf4j:slf4j-api:latest.release")
     testImplementation("com.google.testing.compile:compile-testing:latest.release")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,6 @@ dependencies {
     // Needed for annotation processing tests
     testImplementation(files(tools))
     testImplementation("org.openrewrite:rewrite-java:latest.integration")
-    testImplementation("org.openrewrite.recipe:rewrite-static-analysis:latest.integration")
     testImplementation("org.slf4j:slf4j-api:latest.release")
     testImplementation("com.google.testing.compile:compile-testing:latest.release")
 

--- a/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
@@ -93,8 +93,8 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
     }
 
     static Set<String> DO_AFTER_VISIT = Stream.of(
-            "org.openrewrite.java.ShortenFullyQualifiedTypeReferences",
-            "org.openrewrite.staticanalysis.UnnecessaryParentheses"
+            "new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor()",
+            "new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor()"
     ).collect(Collectors.toCollection(LinkedHashSet::new));
 
     static ClassValue<List<String>> LST_TYPE_MAP = new ClassValue<List<String>>() {
@@ -319,7 +319,7 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
                             }
                         }
                         for (String doAfterVisit : DO_AFTER_VISIT) {
-                            recipe.append("                    doAfterVisit(new " + doAfterVisit + "().getVisitor());\n");
+                            recipe.append("                    doAfterVisit(" + doAfterVisit + ");\n");
                         }
                         if (parameters.isEmpty()) {
                             recipe.append("                    return " + after + ".apply(getCursor(), elem.getCoordinates().replace());\n");

--- a/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
@@ -92,6 +92,11 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
         PRIMITIVE_TYPE_MAP.put(void.class.getName(), Void.class.getSimpleName());
     }
 
+    static Set<String> DO_AFTER_VISIT = Stream.of(
+            "org.openrewrite.java.ShortenFullyQualifiedTypeReferences",
+            "org.openrewrite.staticanalysis.UnnecessaryParentheses"
+    ).collect(Collectors.toCollection(LinkedHashSet::new));
+
     static ClassValue<List<String>> LST_TYPE_MAP = new ClassValue<List<String>>() {
         @Override
         protected List<String> computeValue(Class<?> type) {
@@ -313,7 +318,9 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
                                 recipe.append("                    maybeAddImport(\"" + import_.substring(0, dot) + "\", \"" + import_.substring(dot + 1) + "\");\n");
                             }
                         }
-                        recipe.append("                    doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());\n");
+                        for (String doAfterVisit : DO_AFTER_VISIT) {
+                            recipe.append("                    doAfterVisit(new " + doAfterVisit + "().getVisitor());\n");
+                        }
                         if (parameters.isEmpty()) {
                             recipe.append("                    return " + after + ".apply(getCursor(), elem.getCoordinates().replace());\n");
                         } else {
@@ -344,7 +351,6 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
                             out.write("import org.openrewrite.TreeVisitor;\n");
                             out.write("import org.openrewrite.java.JavaTemplate;\n");
                             out.write("import org.openrewrite.java.JavaVisitor;\n");
-                            out.write("import org.openrewrite.java.ShortenFullyQualifiedTypeReferences;\n");
                             out.write("import org.openrewrite.java.template.Primitive;\n");
                             out.write("import org.openrewrite.java.tree.*;\n");
                             if (outerClassRequired) {

--- a/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
@@ -71,23 +71,18 @@ class RefasterTemplateProcessorTest {
     @NotNull
     private static Collection<File> classpath() {
         return Arrays.asList(
-          fileForClass(BeforeTemplate.class.getName()),
-          fileForClass(AfterTemplate.class.getName()),
-          fileForClass(com.sun.tools.javac.tree.JCTree.class.getName()),
-          fileForClass(org.openrewrite.Recipe.class.getName()),
-          fileForClass(org.openrewrite.java.JavaTemplate.class.getName()),
-          fileForClass(org.slf4j.Logger.class.getName())
+          fileForClass(BeforeTemplate.class),
+          fileForClass(AfterTemplate.class),
+          fileForClass(com.sun.tools.javac.tree.JCTree.class),
+          fileForClass(org.openrewrite.Recipe.class),
+          fileForClass(org.openrewrite.java.JavaTemplate.class),
+          fileForClass(org.openrewrite.staticanalysis.UnnecessaryParentheses.class),
+          fileForClass(org.slf4j.Logger.class)
         );
     }
 
     // As per https://github.com/google/auto/blob/auto-value-1.10.2/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java#L99
-    static File fileForClass(String className) {
-        Class<?> c;
-        try {
-            c = Class.forName(className);
-        } catch (ClassNotFoundException e) {
-            throw new IllegalArgumentException(e);
-        }
+    static File fileForClass(Class<?> c) {
         URL url = c.getProtectionDomain().getCodeSource().getLocation();
         assert url.getProtocol().equals("file");
         return new File(url.getPath());

--- a/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
@@ -76,7 +76,6 @@ class RefasterTemplateProcessorTest {
           fileForClass(com.sun.tools.javac.tree.JCTree.class),
           fileForClass(org.openrewrite.Recipe.class),
           fileForClass(org.openrewrite.java.JavaTemplate.class),
-          fileForClass(org.openrewrite.staticanalysis.UnnecessaryParentheses.class),
           fileForClass(org.slf4j.Logger.class)
         );
     }

--- a/src/test/java/org/openrewrite/java/template/TemplateProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/template/TemplateProcessorTest.java
@@ -62,7 +62,6 @@ class TemplateProcessorTest {
           fileForClass(com.sun.tools.javac.tree.JCTree.class),
           fileForClass(org.openrewrite.Recipe.class),
           fileForClass(org.openrewrite.java.JavaTemplate.class),
-          fileForClass(org.openrewrite.staticanalysis.UnnecessaryParentheses.class),
           fileForClass(org.slf4j.Logger.class)
         );
     }

--- a/src/test/java/org/openrewrite/java/template/TemplateProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/template/TemplateProcessorTest.java
@@ -57,23 +57,18 @@ class TemplateProcessorTest {
     @NotNull
     private static Collection<File> classpath() {
         return Arrays.asList(
-          fileForClass(BeforeTemplate.class.getName()),
-          fileForClass(AfterTemplate.class.getName()),
-          fileForClass(com.sun.tools.javac.tree.JCTree.class.getName()),
-          fileForClass(org.openrewrite.Recipe.class.getName()),
-          fileForClass(org.openrewrite.java.JavaTemplate.class.getName()),
-          fileForClass(org.slf4j.Logger.class.getName())
+          fileForClass(BeforeTemplate.class),
+          fileForClass(AfterTemplate.class),
+          fileForClass(com.sun.tools.javac.tree.JCTree.class),
+          fileForClass(org.openrewrite.Recipe.class),
+          fileForClass(org.openrewrite.java.JavaTemplate.class),
+          fileForClass(org.openrewrite.staticanalysis.UnnecessaryParentheses.class),
+          fileForClass(org.slf4j.Logger.class)
         );
     }
 
     // As per https://github.com/google/auto/blob/auto-value-1.10.2/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java#L99
-    static File fileForClass(String className) {
-        Class<?> c;
-        try {
-            c = Class.forName(className);
-        } catch (ClassNotFoundException e) {
-            throw new IllegalArgumentException(e);
-        }
+    static File fileForClass(Class<?> c) {
         URL url = c.getProtectionDomain().getCodeSource().getLocation();
         assert url.getProtocol().equals("file");
         return new File(url.getPath());

--- a/src/test/resources/recipes/MultipleDereferencesRecipes.java
+++ b/src/test/resources/recipes/MultipleDereferencesRecipes.java
@@ -54,7 +54,7 @@ public final class MultipleDereferencesRecipes extends Recipe {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
-                        doAfterVisit(new org.openrewrite.staticanalysis.UnnecessaryParentheses().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(0));
                     }
                     return super.visitMethodInvocation(elem, ctx);
@@ -87,7 +87,7 @@ public final class MultipleDereferencesRecipes extends Recipe {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
-                        doAfterVisit(new org.openrewrite.staticanalysis.UnnecessaryParentheses().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace());
                     }
                     return super.visitBinary(elem, ctx);

--- a/src/test/resources/recipes/MultipleDereferencesRecipes.java
+++ b/src/test/resources/recipes/MultipleDereferencesRecipes.java
@@ -5,7 +5,6 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
-import org.openrewrite.java.ShortenFullyQualifiedTypeReferences;
 import org.openrewrite.java.template.Primitive;
 import org.openrewrite.java.tree.*;
 
@@ -54,7 +53,8 @@ public final class MultipleDereferencesRecipes extends Recipe {
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
-                        doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
+                        doAfterVisit(new org.openrewrite.staticanalysis.UnnecessaryParentheses().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(0));
                     }
                     return super.visitMethodInvocation(elem, ctx);
@@ -86,7 +86,8 @@ public final class MultipleDereferencesRecipes extends Recipe {
                 public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
-                        doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
+                        doAfterVisit(new org.openrewrite.staticanalysis.UnnecessaryParentheses().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace());
                     }
                     return super.visitBinary(elem, ctx);

--- a/src/test/resources/recipes/ShouldAddImportsRecipes.java
+++ b/src/test/resources/recipes/ShouldAddImportsRecipes.java
@@ -1,3 +1,4 @@
+
 package foo;
 
 import org.openrewrite.ExecutionContext;
@@ -5,13 +6,12 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
-import org.openrewrite.java.ShortenFullyQualifiedTypeReferences;
 import org.openrewrite.java.template.Primitive;
 import org.openrewrite.java.tree.*;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
+
 
 public final class ShouldAddImportsRecipes extends Recipe {
 
@@ -33,7 +33,6 @@ public final class ShouldAddImportsRecipes extends Recipe {
                 new ObjectsEqualsRecipe()
         );
     }
-
     public static class StringValueOfRecipe extends Recipe {
 
         @Override
@@ -43,21 +42,21 @@ public final class ShouldAddImportsRecipes extends Recipe {
 
         @Override
         public String getDescription() {
-            return "Recipe created for the following Refaster template:\n```java\npublic static class StringValueOf {\n    \n    @BeforeTemplate()\n    String before(String s) {\n        return String.valueOf(s);\n    }\n    \n    @AfterTemplate()\n    String after(String s) {\n        return Objects.toString(s);\n    }\n}\n```\n.";
+            return "Recipe created for the following Refaster template:\n```java\npublic static class StringValueOf {\n    \n    @BeforeTemplate()\n    String before(String s) {\n        return String.valueOf(s);\n    }\n    \n    @AfterTemplate()\n    String after(String s) {\n        return java.util.Objects.toString(s);\n    }\n}\n```\n.";
         }
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             return new JavaVisitor<ExecutionContext>() {
                 final JavaTemplate before = JavaTemplate.compile(this, "before", (JavaTemplate.F1<?, ?>) (String s) -> String.valueOf(s)).build();
-                final JavaTemplate after = JavaTemplate.compile(this, "after", (JavaTemplate.F1<?, ?>) (String s) -> Objects.toString(s)).build();
+                final JavaTemplate after = JavaTemplate.compile(this, "after", (JavaTemplate.F1<?, ?>) (String s) -> java.util.Objects.toString(s)).build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
-                        maybeAddImport("java.util.Objects");
-                        doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
+                        doAfterVisit(new org.openrewrite.staticanalysis.UnnecessaryParentheses().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                     }
                     return super.visitMethodInvocation(elem, ctx);
@@ -76,21 +75,21 @@ public final class ShouldAddImportsRecipes extends Recipe {
 
         @Override
         public String getDescription() {
-            return "Recipe created for the following Refaster template:\n```java\npublic static class ObjectsEquals {\n    \n    @BeforeTemplate()\n    boolean before(int a, int b) {\n        return Objects.equals(a, b);\n    }\n    \n    @AfterTemplate()\n    boolean after(int a, int b) {\n        return a == b;\n    }\n}\n```\n.";
+            return "Recipe created for the following Refaster template:\n```java\npublic static class ObjectsEquals {\n    \n    @BeforeTemplate()\n    boolean before(int a, int b) {\n        return java.util.Objects.equals(a, b);\n    }\n    \n    @AfterTemplate()\n    boolean after(int a, int b) {\n        return a == b;\n    }\n}\n```\n.";
         }
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             return new JavaVisitor<ExecutionContext>() {
-                final JavaTemplate before = JavaTemplate.compile(this, "before", (JavaTemplate.F2<?, ?, ?>) (@Primitive Integer a, @Primitive Integer b) -> Objects.equals(a, b)).build();
+                final JavaTemplate before = JavaTemplate.compile(this, "before", (JavaTemplate.F2<?, ?, ?>) (@Primitive Integer a, @Primitive Integer b) -> java.util.Objects.equals(a, b)).build();
                 final JavaTemplate after = JavaTemplate.compile(this, "after", (@Primitive Integer a, @Primitive Integer b) -> a == b).build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
-                        maybeRemoveImport("java.util.Objects");
-                        doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
+                        doAfterVisit(new org.openrewrite.staticanalysis.UnnecessaryParentheses().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1));
                     }
                     return super.visitMethodInvocation(elem, ctx);

--- a/src/test/resources/recipes/ShouldAddImportsRecipes.java
+++ b/src/test/resources/recipes/ShouldAddImportsRecipes.java
@@ -1,4 +1,3 @@
-
 package foo;
 
 import org.openrewrite.ExecutionContext;
@@ -12,6 +11,7 @@ import org.openrewrite.java.tree.*;
 import java.util.Arrays;
 import java.util.List;
 
+import java.util.Objects;
 
 public final class ShouldAddImportsRecipes extends Recipe {
 
@@ -42,19 +42,20 @@ public final class ShouldAddImportsRecipes extends Recipe {
 
         @Override
         public String getDescription() {
-            return "Recipe created for the following Refaster template:\n```java\npublic static class StringValueOf {\n    \n    @BeforeTemplate()\n    String before(String s) {\n        return String.valueOf(s);\n    }\n    \n    @AfterTemplate()\n    String after(String s) {\n        return java.util.Objects.toString(s);\n    }\n}\n```\n.";
+            return "Recipe created for the following Refaster template:\n```java\npublic static class StringValueOf {\n    \n    @BeforeTemplate()\n    String before(String s) {\n        return String.valueOf(s);\n    }\n    \n    @AfterTemplate()\n    String after(String s) {\n        return Objects.toString(s);\n    }\n}\n```\n.";
         }
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             return new JavaVisitor<ExecutionContext>() {
                 final JavaTemplate before = JavaTemplate.compile(this, "before", (JavaTemplate.F1<?, ?>) (String s) -> String.valueOf(s)).build();
-                final JavaTemplate after = JavaTemplate.compile(this, "after", (JavaTemplate.F1<?, ?>) (String s) -> java.util.Objects.toString(s)).build();
+                final JavaTemplate after = JavaTemplate.compile(this, "after", (JavaTemplate.F1<?, ?>) (String s) -> Objects.toString(s)).build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
+                        maybeAddImport("java.util.Objects");
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                         doAfterVisit(new org.openrewrite.staticanalysis.UnnecessaryParentheses().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
@@ -75,19 +76,20 @@ public final class ShouldAddImportsRecipes extends Recipe {
 
         @Override
         public String getDescription() {
-            return "Recipe created for the following Refaster template:\n```java\npublic static class ObjectsEquals {\n    \n    @BeforeTemplate()\n    boolean before(int a, int b) {\n        return java.util.Objects.equals(a, b);\n    }\n    \n    @AfterTemplate()\n    boolean after(int a, int b) {\n        return a == b;\n    }\n}\n```\n.";
+            return "Recipe created for the following Refaster template:\n```java\npublic static class ObjectsEquals {\n    \n    @BeforeTemplate()\n    boolean before(int a, int b) {\n        return Objects.equals(a, b);\n    }\n    \n    @AfterTemplate()\n    boolean after(int a, int b) {\n        return a == b;\n    }\n}\n```\n.";
         }
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             return new JavaVisitor<ExecutionContext>() {
-                final JavaTemplate before = JavaTemplate.compile(this, "before", (JavaTemplate.F2<?, ?, ?>) (@Primitive Integer a, @Primitive Integer b) -> java.util.Objects.equals(a, b)).build();
+                final JavaTemplate before = JavaTemplate.compile(this, "before", (JavaTemplate.F2<?, ?, ?>) (@Primitive Integer a, @Primitive Integer b) -> Objects.equals(a, b)).build();
                 final JavaTemplate after = JavaTemplate.compile(this, "after", (@Primitive Integer a, @Primitive Integer b) -> a == b).build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
+                        maybeRemoveImport("java.util.Objects");
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                         doAfterVisit(new org.openrewrite.staticanalysis.UnnecessaryParentheses().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1));

--- a/src/test/resources/recipes/ShouldAddImportsRecipes.java
+++ b/src/test/resources/recipes/ShouldAddImportsRecipes.java
@@ -58,7 +58,7 @@ public final class ShouldAddImportsRecipes extends Recipe {
                     if ((matcher = before.matcher(getCursor())).find()) {
                         maybeAddImport("java.util.Objects");
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
-                        doAfterVisit(new org.openrewrite.staticanalysis.UnnecessaryParentheses().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                     }
                     return super.visitMethodInvocation(elem, ctx);
@@ -93,7 +93,7 @@ public final class ShouldAddImportsRecipes extends Recipe {
                     if ((matcher = equals.matcher(getCursor())).find() || (matcher = compareZero.matcher(getCursor())).find()) {
                         maybeRemoveImport("java.util.Objects");
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
-                        doAfterVisit(new org.openrewrite.staticanalysis.UnnecessaryParentheses().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
                         return isis.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1));
                     }
                     return super.visitMethodInvocation(elem, ctx);

--- a/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
+++ b/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
@@ -54,7 +54,7 @@ public final class ShouldSupportNestedClassesRecipes extends Recipe {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
-                        doAfterVisit(new org.openrewrite.staticanalysis.UnnecessaryParentheses().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                     }
                     return super.visitBinary(elem, ctx);
@@ -87,7 +87,7 @@ public final class ShouldSupportNestedClassesRecipes extends Recipe {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
-                        doAfterVisit(new org.openrewrite.staticanalysis.UnnecessaryParentheses().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                     }
                     return super.visitBinary(elem, ctx);

--- a/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
+++ b/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
@@ -5,7 +5,6 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
-import org.openrewrite.java.ShortenFullyQualifiedTypeReferences;
 import org.openrewrite.java.template.Primitive;
 import org.openrewrite.java.tree.*;
 
@@ -54,7 +53,8 @@ public final class ShouldSupportNestedClassesRecipes extends Recipe {
                 public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
-                        doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
+                        doAfterVisit(new org.openrewrite.staticanalysis.UnnecessaryParentheses().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                     }
                     return super.visitBinary(elem, ctx);
@@ -86,7 +86,8 @@ public final class ShouldSupportNestedClassesRecipes extends Recipe {
                 public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
-                        doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
+                        doAfterVisit(new org.openrewrite.staticanalysis.UnnecessaryParentheses().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                     }
                     return super.visitBinary(elem, ctx);

--- a/src/test/resources/recipes/UseStringIsEmptyRecipe.java
+++ b/src/test/resources/recipes/UseStringIsEmptyRecipe.java
@@ -5,7 +5,6 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
-import org.openrewrite.java.ShortenFullyQualifiedTypeReferences;
 import org.openrewrite.java.template.Primitive;
 import org.openrewrite.java.tree.*;
 
@@ -31,7 +30,8 @@ public class UseStringIsEmptyRecipe extends Recipe {
             public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
                 if ((matcher = before.matcher(getCursor())).find()) {
-                    doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
+                    doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
+                    doAfterVisit(new org.openrewrite.staticanalysis.UnnecessaryParentheses().getVisitor());
                     return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                 }
                 return super.visitBinary(elem, ctx);
@@ -40,4 +40,3 @@ public class UseStringIsEmptyRecipe extends Recipe {
         };
     }
 }
-

--- a/src/test/resources/recipes/UseStringIsEmptyRecipe.java
+++ b/src/test/resources/recipes/UseStringIsEmptyRecipe.java
@@ -31,7 +31,7 @@ public class UseStringIsEmptyRecipe extends Recipe {
                 JavaTemplate.Matcher matcher;
                 if ((matcher = before.matcher(getCursor())).find()) {
                     doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
-                    doAfterVisit(new org.openrewrite.staticanalysis.UnnecessaryParentheses().getVisitor());
+                    doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
                     return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                 }
                 return super.visitBinary(elem, ctx);


### PR DESCRIPTION
## What's your motivation?
Until we update the JavaTemplate to detect and insert parentheses around for instance binary expressions, we need a quick way to move along https://github.com/openrewrite/rewrite-migrate-java/pull/271 ; With this change we're able to add parentheses to the templates defined there, which are then cleaned up through `UnnecessaryParentheses`.

## Have you considered any alternatives or workarounds?
We could _always_ add parentheses in the JavaTemplate Strings produced by `TemplateProcessor` here; that might be a bit excessive, but would prevent us from having to add those parentheses to rewrite-migrate-java.

## Any additional context
- https://github.com/openrewrite/rewrite-migrate-java/pull/271