### PR TITLE
Generate uses type and uses method

### DIFF
--- a/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
@@ -288,14 +288,15 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
                                 .collect(Collectors.toSet());
                         Set<String> usedTypes = new LinkedHashSet<>();
                         for (String import_ : imports.values().stream().flatMap(Set::stream).collect(Collectors.toSet())) {
+                            if (beforeImports.contains(import_)) {
+                                usedTypes.add(import_);
+                            }
                             if (import_.startsWith("java.lang.")) {
                                 continue;
                             }
                             if (beforeImports.contains(import_) && afterImports.contains(import_)) {
-                                usedTypes.add(import_);
                             } else if (beforeImports.contains(import_)) {
                                 recipe.append("                    maybeRemoveImport(\"" + import_ + "\");\n");
-                                usedTypes.add(import_);
                             } else if (afterImports.contains(import_)) {
                                 recipe.append("                    maybeAddImport(\"" + import_ + "\");\n");
                             }
@@ -317,15 +318,16 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
                                 .collect(Collectors.toSet());
                         Set<String> usedMethods = new LinkedHashSet<>();
                         for (String import_ : staticImports.values().stream().flatMap(Set::stream).collect(Collectors.toSet())) {
+                            int dot = import_.lastIndexOf('.');
+                            if (beforeImports.contains(import_)) {
+                                usedMethods.add(import_.substring(0, dot) + ' ' + import_.substring(dot + 1) + "(..)");
+                            }
                             if (import_.startsWith("java.lang.")) {
                                 continue;
                             }
-                            int dot = import_.lastIndexOf('.');
                             if (beforeImports.contains(import_) && afterImports.contains(import_)) {
-                                usedMethods.add(import_.substring(0, dot) + ' ' + import_.substring(dot + 1) + "(..)");
                             } else if (beforeImports.contains(import_)) {
                                 recipe.append("                    maybeRemoveImport(\"" + import_ + "\");\n");
-                                usedMethods.add(import_.substring(0, dot) + ' ' + import_.substring(dot + 1) + "(..)");
                             } else if (afterImports.contains(import_)) {
                                 recipe.append("                    maybeAddImport(\"" + import_.substring(0, dot) + "\", \"" + import_.substring(dot + 1) + "\");\n");
                             }

--- a/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
@@ -447,7 +447,7 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
 
                     Set<String> localImports = imports.getOrDefault(beforeTemplate, Collections.emptySet());
                     for (String import_ : localImports) {
-                        usesVisitors.add("new UsesType<>(\"" + import_ + "\", false)");
+                        usesVisitors.add("new UsesType<>(\"" + import_ + "\", true)");
                     }
                     Set<String> localStaticImports = staticImports.getOrDefault(beforeTemplate, Collections.emptySet());
                     for (String import_ : localStaticImports) {

--- a/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
@@ -287,12 +287,13 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
                                 continue;
                             }
                             if (beforeImports.contains(import_) && afterImports.contains(import_)) {
+                                usedTypes.add(import_);
                             } else if (beforeImports.contains(import_)) {
                                 recipe.append("                    maybeRemoveImport(\"" + import_ + "\");\n");
+                                usedTypes.add(import_);
                             } else if (afterImports.contains(import_)) {
                                 recipe.append("                    maybeAddImport(\"" + import_ + "\");\n");
                             }
-                            usedTypes.add(import_);
                         }
                         if (!usedTypes.isEmpty()) {
                             if (usedTypes.size() == 1) {
@@ -318,13 +319,14 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
                             }
                             int dot = import_.lastIndexOf('.');
                             if (beforeImports.contains(import_) && afterImports.contains(import_)) {
+                                usedMethods.add(import_.substring(0, dot) + ' ' + import_.substring(dot + 1) + "(..)");
                             } else if (beforeImports.contains(import_)) {
                                 recipe.append("                    maybeRemoveImport(\"" + import_ + "\");\n");
+                                usedMethods.add(import_.substring(0, dot) + ' ' + import_.substring(dot + 1) + "(..)");
                             } else if (afterImports.contains(import_)) {
                                 String className = import_.substring(0, dot);
                                 recipe.append("                    maybeAddImport(\"" + className + "\", \"" + import_.substring(dot + 1) + "\");\n");
                             }
-                            usedMethods.add(import_.substring(0, dot) + ' ' + import_.substring(dot + 1) + "(..)");
                         }
                         if (!usedMethods.isEmpty()) {
                             if (usedMethods.size() == 1) {

--- a/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
@@ -36,6 +36,7 @@ class RefasterTemplateProcessorTest {
     @ParameterizedTest
     @ValueSource(strings = {
       "UseStringIsEmpty",
+      "NestedPreconditions"
     })
     void generateRecipe(String recipeName) {
         // As per https://github.com/google/compile-testing/blob/v0.21.0/src/main/java/com/google/testing/compile/package-info.java#L53-L55

--- a/src/test/resources/recipes/MultipleDereferencesRecipes.java
+++ b/src/test/resources/recipes/MultipleDereferencesRecipes.java
@@ -1,16 +1,19 @@
 package foo;
 
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.ShortenFullyQualifiedTypeReferences;
+import org.openrewrite.java.search.*;
 import org.openrewrite.java.template.Primitive;
 import org.openrewrite.java.tree.*;
 
 import java.util.Arrays;
 import java.util.List;
+
 
 public final class MultipleDereferencesRecipes extends Recipe {
 
@@ -32,6 +35,7 @@ public final class MultipleDereferencesRecipes extends Recipe {
                 new EqualsItselfRecipe()
         );
     }
+
     public static class StringIsEmptyRecipe extends Recipe {
 
         @Override
@@ -46,7 +50,7 @@ public final class MultipleDereferencesRecipes extends Recipe {
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
-            return new JavaVisitor<ExecutionContext>() {
+            JavaVisitor<ExecutionContext> javaVisitor = new JavaVisitor<ExecutionContext>() {
                 final JavaTemplate before = JavaTemplate.compile(this, "before", (JavaTemplate.F1<?, ?>) (String s) -> s.isEmpty()).build();
                 final JavaTemplate after = JavaTemplate.compile(this, "after", (String s) -> s != null && s.length() == 0).build();
 
@@ -61,6 +65,7 @@ public final class MultipleDereferencesRecipes extends Recipe {
                 }
 
             };
+            return javaVisitor;
         }
     }
 
@@ -78,7 +83,7 @@ public final class MultipleDereferencesRecipes extends Recipe {
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
-            return new JavaVisitor<ExecutionContext>() {
+            JavaVisitor<ExecutionContext> javaVisitor = new JavaVisitor<ExecutionContext>() {
                 final JavaTemplate before = JavaTemplate.compile(this, "before", (Object o) -> o == o).build();
                 final JavaTemplate after = JavaTemplate.compile(this, "after", (Object o) -> true).build();
 
@@ -93,6 +98,7 @@ public final class MultipleDereferencesRecipes extends Recipe {
                 }
 
             };
+            return javaVisitor;
         }
     }
 

--- a/src/test/resources/recipes/NestedPreconditions.java
+++ b/src/test/resources/recipes/NestedPreconditions.java
@@ -1,0 +1,23 @@
+package foo;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+
+import java.util.*;
+
+public class NestedPreconditions {
+    @BeforeTemplate
+    Map hashMap(int size) {
+        return new HashMap(size);
+    }
+
+    @BeforeTemplate
+    Map linkedHashMap(int size) {
+        return new LinkedHashMap(size);
+    }
+
+    @AfterTemplate
+    Map hashtable(int size) {
+        return new Hashtable(size);
+    }
+}

--- a/src/test/resources/recipes/NestedPreconditionsRecipe.java
+++ b/src/test/resources/recipes/NestedPreconditionsRecipe.java
@@ -52,8 +52,8 @@ public class NestedPreconditionsRecipe extends Recipe {
         };
         return Preconditions.check(
                 Preconditions.or(
-                        Preconditions.and(new UsesType<>("java.util.HashMap", false), new UsesType<>("java.util.Map", false)),
-                        Preconditions.and(new UsesType<>("java.util.LinkedHashMap", false), new UsesType<>("java.util.Map", false))),
+                        Preconditions.and(new UsesType<>("java.util.HashMap", true), new UsesType<>("java.util.Map", true)),
+                        Preconditions.and(new UsesType<>("java.util.LinkedHashMap", true), new UsesType<>("java.util.Map", true))),
                 javaVisitor);
     }
 }

--- a/src/test/resources/recipes/NestedPreconditionsRecipe.java
+++ b/src/test/resources/recipes/NestedPreconditionsRecipe.java
@@ -1,0 +1,59 @@
+
+package foo;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.search.*;
+import org.openrewrite.java.template.Primitive;
+import org.openrewrite.java.tree.*;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Hashtable;
+
+public class NestedPreconditionsRecipe extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Refaster template `NestedPreconditions`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Recipe created for the following Refaster template:\n```java\npublic class NestedPreconditions {\n    \n    @BeforeTemplate()\n    Map hashMap(int size) {\n        return new HashMap(size);\n    }\n    \n    @BeforeTemplate()\n    Map linkedHashMap(int size) {\n        return new LinkedHashMap(size);\n    }\n    \n    @AfterTemplate()\n    Map hashtable(int size) {\n        return new Hashtable(size);\n    }\n}\n```\n.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        JavaVisitor<ExecutionContext> javaVisitor = new JavaVisitor<ExecutionContext>() {
+            final JavaTemplate hashMap = JavaTemplate.compile(this, "hashMap", (JavaTemplate.F1<?, ?>) (@Primitive Integer size) -> new HashMap(size)).build();
+            final JavaTemplate linkedHashMap = JavaTemplate.compile(this, "linkedHashMap", (JavaTemplate.F1<?, ?>) (@Primitive Integer size) -> new LinkedHashMap(size)).build();
+            final JavaTemplate hashtable = JavaTemplate.compile(this, "hashtable", (JavaTemplate.F1<?, ?>) (@Primitive Integer size) -> new Hashtable(size)).build();
+
+            @Override
+            public J visitExpression(Expression elem, ExecutionContext ctx) {
+                JavaTemplate.Matcher matcher;
+                if ((matcher = hashMap.matcher(getCursor())).find() || (matcher = linkedHashMap.matcher(getCursor())).find()) {
+                    maybeRemoveImport("java.util.LinkedHashMap");
+                    maybeRemoveImport("java.util.HashMap");
+                    maybeAddImport("java.util.Hashtable");
+                    doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
+                    doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
+                    return hashtable.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
+                }
+                return super.visitExpression(elem, ctx);
+            }
+
+        };
+        return Preconditions.check(
+                Preconditions.or(
+                        Preconditions.and(new UsesType<>("java.util.HashMap", false), new UsesType<>("java.util.Map", false)),
+                        Preconditions.and(new UsesType<>("java.util.LinkedHashMap", false), new UsesType<>("java.util.Map", false))),
+                javaVisitor);
+    }
+}

--- a/src/test/resources/recipes/ShouldAddImports.java
+++ b/src/test/resources/recipes/ShouldAddImports.java
@@ -5,6 +5,8 @@ import com.google.errorprone.refaster.annotation.BeforeTemplate;
 
 import java.util.Objects;
 
+import static java.util.Objects.hash;
+
 public class ShouldAddImports {
 
     public static class StringValueOf {
@@ -32,6 +34,18 @@ public class ShouldAddImports {
         @AfterTemplate
         boolean isis(int a, int b) {
             return a == b;
+        }
+    }
+
+    public static class StaticImportObjectsHash {
+        @BeforeTemplate
+        int before(String s) {
+            return hash(s);
+        }
+
+        @AfterTemplate
+        int after(String s) {
+            return s.hashCode();
         }
     }
 }

--- a/src/test/resources/recipes/ShouldAddImportsRecipes.java
+++ b/src/test/resources/recipes/ShouldAddImportsRecipes.java
@@ -107,7 +107,7 @@ public final class ShouldAddImportsRecipes extends Recipe {
 
             };
             return Preconditions.check(
-                    new UsesType<>("java.util.Objects", false),
+                    new UsesType<>("java.util.Objects", true),
                     javaVisitor);
         }
     }

--- a/src/test/resources/recipes/ShouldAddImportsRecipes.java
+++ b/src/test/resources/recipes/ShouldAddImportsRecipes.java
@@ -2,11 +2,13 @@
 package foo;
 
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.ShortenFullyQualifiedTypeReferences;
+import org.openrewrite.java.search.*;
 import org.openrewrite.java.template.Primitive;
 import org.openrewrite.java.tree.*;
 
@@ -35,6 +37,7 @@ public final class ShouldAddImportsRecipes extends Recipe {
                 new ObjectsEqualsRecipe()
         );
     }
+
     public static class StringValueOfRecipe extends Recipe {
 
         @Override
@@ -49,7 +52,7 @@ public final class ShouldAddImportsRecipes extends Recipe {
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
-            return new JavaVisitor<ExecutionContext>() {
+            JavaVisitor<ExecutionContext> javaVisitor = new JavaVisitor<ExecutionContext>() {
                 final JavaTemplate before = JavaTemplate.compile(this, "before", (JavaTemplate.F1<?, ?>) (String s) -> String.valueOf(s)).build();
                 final JavaTemplate after = JavaTemplate.compile(this, "after", (JavaTemplate.F1<?, ?>) (String s) -> Objects.toString(s)).build();
 
@@ -63,8 +66,10 @@ public final class ShouldAddImportsRecipes extends Recipe {
                     }
                     return super.visitMethodInvocation(elem, ctx);
                 }
-
             };
+            return Preconditions.check(Preconditions.or(
+                            Preconditions.and(new UsesType<>("java.util.Objects", false))),
+                    javaVisitor);
         }
     }
 
@@ -82,7 +87,7 @@ public final class ShouldAddImportsRecipes extends Recipe {
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
-            return new JavaVisitor<ExecutionContext>() {
+            JavaVisitor<ExecutionContext> javaVisitor = new JavaVisitor<ExecutionContext>() {
                 final JavaTemplate equals = JavaTemplate.compile(this, "equals", (JavaTemplate.F2<?, ?, ?>) (@Primitive Integer a, @Primitive Integer b) -> Objects.equals(a, b)).build();
                 final JavaTemplate compareZero = JavaTemplate.compile(this, "compareZero", (@Primitive Integer a, @Primitive Integer b) -> Integer.compare(a, b) == 0).build();
                 final JavaTemplate isis = JavaTemplate.compile(this, "isis", (@Primitive Integer a, @Primitive Integer b) -> a == b).build();
@@ -97,8 +102,10 @@ public final class ShouldAddImportsRecipes extends Recipe {
                     }
                     return super.visitMethodInvocation(elem, ctx);
                 }
-
             };
+            return Preconditions.check(Preconditions.or(
+                            Preconditions.and(new UsesType<>("java.util.Objects", false))),
+                    javaVisitor);
         }
     }
 

--- a/src/test/resources/recipes/ShouldAddImportsRecipes.java
+++ b/src/test/resources/recipes/ShouldAddImportsRecipes.java
@@ -71,9 +71,7 @@ public final class ShouldAddImportsRecipes extends Recipe {
                 }
 
             };
-            return Preconditions.check(
-                    new UsesType<>("java.util.Objects", false),
-                    javaVisitor);
+            return javaVisitor;
         }
     }
 
@@ -144,9 +142,8 @@ public final class ShouldAddImportsRecipes extends Recipe {
                 }
 
             };
-            return Preconditions.check(Preconditions.or(
-                            new UsesType<>("java.util.Objects", false),
-                            new UsesMethod<>("java.util.Objects hash(..)")),
+            return Preconditions.check(
+                    new UsesMethod<>("java.util.Objects hash(..)"),
                     javaVisitor);
         }
     }

--- a/src/test/resources/recipes/ShouldAddImportsRecipes.java
+++ b/src/test/resources/recipes/ShouldAddImportsRecipes.java
@@ -1,4 +1,3 @@
-
 package foo;
 
 import org.openrewrite.ExecutionContext;
@@ -136,7 +135,8 @@ public final class ShouldAddImportsRecipes extends Recipe {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
                         maybeRemoveImport("java.util.Objects.hash");
-                        doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                     }
                     return super.visitMethodInvocation(elem, ctx);

--- a/src/test/resources/recipes/ShouldAddImportsRecipes.java
+++ b/src/test/resources/recipes/ShouldAddImportsRecipes.java
@@ -67,8 +67,8 @@ public final class ShouldAddImportsRecipes extends Recipe {
                     return super.visitMethodInvocation(elem, ctx);
                 }
             };
-            return Preconditions.check(Preconditions.or(
-                            Preconditions.and(new UsesType<>("java.util.Objects", false))),
+            return Preconditions.check(
+                            new UsesType<>("java.util.Objects", false),
                     javaVisitor);
         }
     }
@@ -103,8 +103,8 @@ public final class ShouldAddImportsRecipes extends Recipe {
                     return super.visitMethodInvocation(elem, ctx);
                 }
             };
-            return Preconditions.check(Preconditions.or(
-                            Preconditions.and(new UsesType<>("java.util.Objects", false))),
+            return Preconditions.check(
+                            new UsesType<>("java.util.Objects", false),
                     javaVisitor);
         }
     }

--- a/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
+++ b/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
@@ -1,16 +1,19 @@
 package foo;
 
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.ShortenFullyQualifiedTypeReferences;
+import org.openrewrite.java.search.*;
 import org.openrewrite.java.template.Primitive;
 import org.openrewrite.java.tree.*;
 
 import java.util.Arrays;
 import java.util.List;
+
 
 public final class ShouldSupportNestedClassesRecipes extends Recipe {
 
@@ -23,6 +26,7 @@ public final class ShouldSupportNestedClassesRecipes extends Recipe {
     public String getDescription() {
         return "Refaster template recipes for `foo.ShouldSupportNestedClasses`.";
     }
+
 
     @Override
     public List<Recipe> getRecipeList() {
@@ -46,7 +50,7 @@ public final class ShouldSupportNestedClassesRecipes extends Recipe {
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
-            return new JavaVisitor<ExecutionContext>() {
+            JavaVisitor<ExecutionContext> javaVisitor = new JavaVisitor<ExecutionContext>() {
                 final JavaTemplate before = JavaTemplate.compile(this, "before", (String s) -> s.length() > 0).build();
                 final JavaTemplate after = JavaTemplate.compile(this, "after", (String s) -> !s.isEmpty()).build();
 
@@ -61,6 +65,7 @@ public final class ShouldSupportNestedClassesRecipes extends Recipe {
                 }
 
             };
+            return javaVisitor;
         }
     }
 
@@ -78,7 +83,7 @@ public final class ShouldSupportNestedClassesRecipes extends Recipe {
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
-            return new JavaVisitor<ExecutionContext>() {
+            JavaVisitor<ExecutionContext> javaVisitor = new JavaVisitor<ExecutionContext>() {
                 final JavaTemplate before = JavaTemplate.compile(this, "before", (String s) -> s.length() == 0).build();
                 final JavaTemplate after = JavaTemplate.compile(this, "after", (JavaTemplate.F1<?, ?>) (String s) -> s.isEmpty()).build();
 
@@ -93,6 +98,7 @@ public final class ShouldSupportNestedClassesRecipes extends Recipe {
                 }
 
             };
+            return javaVisitor;
         }
     }
 

--- a/src/test/resources/recipes/UseStringIsEmptyRecipe.java
+++ b/src/test/resources/recipes/UseStringIsEmptyRecipe.java
@@ -1,13 +1,16 @@
 package foo;
 
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.ShortenFullyQualifiedTypeReferences;
+import org.openrewrite.java.search.*;
 import org.openrewrite.java.template.Primitive;
 import org.openrewrite.java.tree.*;
+
 
 public class UseStringIsEmptyRecipe extends Recipe {
 
@@ -23,7 +26,7 @@ public class UseStringIsEmptyRecipe extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new JavaVisitor<ExecutionContext>() {
+        JavaVisitor<ExecutionContext> javaVisitor = new JavaVisitor<ExecutionContext>() {
             final JavaTemplate before = JavaTemplate.compile(this, "before", (String s) -> s.length() > 0).build();
             final JavaTemplate after = JavaTemplate.compile(this, "after", (String s) -> !s.isEmpty()).build();
 
@@ -38,6 +41,6 @@ public class UseStringIsEmptyRecipe extends Recipe {
             }
 
         };
+        return javaVisitor;
     }
 }
-

--- a/src/test/resources/recipes/UseStringIsEmptyRecipe.java
+++ b/src/test/resources/recipes/UseStringIsEmptyRecipe.java
@@ -6,7 +6,6 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
-import org.openrewrite.java.ShortenFullyQualifiedTypeReferences;
 import org.openrewrite.java.search.*;
 import org.openrewrite.java.template.Primitive;
 import org.openrewrite.java.tree.*;


### PR DESCRIPTION
## What's changed?
Generate Preconditions based on imports and static imports used in before templates.

## What's your motivation?
Speed up recipe execution.
Fixes #23

## Anything in particular you'd like reviewers to focus on?
Would we want to detect additional methods now already?
Figured this was good enough to start to limit recipe execution.

## Have you considered any alternatives or workarounds?
We could add a new detector specific for methods used in the before templates, but that's perhaps more work we can do later.

## Any additional context
- https://github.com/openrewrite/rewrite-templating/issues/23
- https://github.com/openrewrite/rewrite-templating/pull/22/
- https://github.com/openrewrite/rewrite-migrate-java/pull/271