### PR TITLE
Clean up nullable and empty string comparisons after visit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     // Needed for annotation processing tests
     testImplementation(files(tools))
     testImplementation("org.openrewrite:rewrite-java:latest.integration")
+    testImplementation("org.openrewrite.recipe:rewrite-static-analysis:latest.integration")
     testImplementation("org.slf4j:slf4j-api:latest.release")
     testImplementation("com.google.testing.compile:compile-testing:latest.release")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,6 @@ dependencies {
     // Needed for annotation processing tests
     testImplementation(files(tools))
     testImplementation("org.openrewrite:rewrite-java:latest.integration")
-    testImplementation("org.openrewrite.recipe:rewrite-static-analysis:latest.integration")
     testImplementation("org.slf4j:slf4j-api:latest.release")
     testImplementation("com.google.testing.compile:compile-testing:latest.release")
 

--- a/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
@@ -94,7 +94,8 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
 
     static Set<String> DO_AFTER_VISIT = Stream.of(
             "new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor()",
-            "new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor()"
+            "new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor()",
+            "new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor()"
     ).collect(Collectors.toCollection(LinkedHashSet::new));
 
     static ClassValue<List<String>> LST_TYPE_MAP = new ClassValue<List<String>>() {

--- a/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
@@ -95,7 +95,7 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
     static Set<String> DO_AFTER_VISIT = Stream.of(
             "new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor()",
             "new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor()",
-            "new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor()"
+            "new org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor()"
     ).collect(Collectors.toCollection(LinkedHashSet::new));
 
     static ClassValue<List<String>> LST_TYPE_MAP = new ClassValue<List<String>>() {

--- a/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
@@ -70,14 +70,15 @@ class RefasterTemplateProcessorTest {
     }
 
     @NotNull
-    private static Collection<File> classpath() {
+    static Collection<File> classpath() {
         return Arrays.asList(
           fileForClass(BeforeTemplate.class),
           fileForClass(AfterTemplate.class),
           fileForClass(com.sun.tools.javac.tree.JCTree.class),
           fileForClass(org.openrewrite.Recipe.class),
           fileForClass(org.openrewrite.java.JavaTemplate.class),
-          fileForClass(org.slf4j.Logger.class)
+          fileForClass(org.slf4j.Logger.class),
+          fileForClass(org.openrewrite.staticanalysis.SimplifyBooleanExpression.class)
         );
     }
 

--- a/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
@@ -77,8 +77,7 @@ class RefasterTemplateProcessorTest {
           fileForClass(com.sun.tools.javac.tree.JCTree.class),
           fileForClass(org.openrewrite.Recipe.class),
           fileForClass(org.openrewrite.java.JavaTemplate.class),
-          fileForClass(org.slf4j.Logger.class),
-          fileForClass(org.openrewrite.staticanalysis.SimplifyBooleanExpression.class)
+          fileForClass(org.slf4j.Logger.class)
         );
     }
 

--- a/src/test/java/org/openrewrite/java/template/TemplateProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/template/TemplateProcessorTest.java
@@ -15,21 +15,14 @@
  */
 package org.openrewrite.java.template;
 
-import com.google.errorprone.refaster.annotation.AfterTemplate;
-import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.io.File;
-import java.net.URL;
-import java.util.Arrays;
-import java.util.Collection;
-
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
+import static org.openrewrite.java.template.RefasterTemplateProcessorTest.classpath;
 
 class TemplateProcessorTest {
 
@@ -54,22 +47,4 @@ class TemplateProcessorTest {
           .hasSourceEquivalentTo(JavaFileObjects.forResource("recipes/ShouldAddClasspathRecipe$" + qualifier + "Recipe$1_after.java"));
     }
 
-    @NotNull
-    private static Collection<File> classpath() {
-        return Arrays.asList(
-          fileForClass(BeforeTemplate.class),
-          fileForClass(AfterTemplate.class),
-          fileForClass(com.sun.tools.javac.tree.JCTree.class),
-          fileForClass(org.openrewrite.Recipe.class),
-          fileForClass(org.openrewrite.java.JavaTemplate.class),
-          fileForClass(org.slf4j.Logger.class)
-        );
-    }
-
-    // As per https://github.com/google/auto/blob/auto-value-1.10.2/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java#L99
-    static File fileForClass(Class<?> c) {
-        URL url = c.getProtectionDomain().getCodeSource().getLocation();
-        assert url.getProtocol().equals("file");
-        return new File(url.getPath());
-    }
 }

--- a/src/test/resources/recipes/MultipleDereferencesRecipes.java
+++ b/src/test/resources/recipes/MultipleDereferencesRecipes.java
@@ -59,7 +59,7 @@ public final class MultipleDereferencesRecipes extends Recipe {
                     if ((matcher = before.matcher(getCursor())).find()) {
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                         doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
-                        doAfterVisit(new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(0));
                     }
                     return super.visitMethodInvocation(elem, ctx);
@@ -94,7 +94,7 @@ public final class MultipleDereferencesRecipes extends Recipe {
                     if ((matcher = before.matcher(getCursor())).find()) {
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                         doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
-                        doAfterVisit(new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace());
                     }
                     return super.visitBinary(elem, ctx);

--- a/src/test/resources/recipes/MultipleDereferencesRecipes.java
+++ b/src/test/resources/recipes/MultipleDereferencesRecipes.java
@@ -59,6 +59,7 @@ public final class MultipleDereferencesRecipes extends Recipe {
                     if ((matcher = before.matcher(getCursor())).find()) {
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                         doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
+                        doAfterVisit(new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(0));
                     }
                     return super.visitMethodInvocation(elem, ctx);
@@ -93,6 +94,7 @@ public final class MultipleDereferencesRecipes extends Recipe {
                     if ((matcher = before.matcher(getCursor())).find()) {
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                         doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
+                        doAfterVisit(new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace());
                     }
                     return super.visitBinary(elem, ctx);

--- a/src/test/resources/recipes/NestedPreconditionsRecipe.java
+++ b/src/test/resources/recipes/NestedPreconditionsRecipe.java
@@ -44,7 +44,7 @@ public class NestedPreconditionsRecipe extends Recipe {
                     maybeAddImport("java.util.Hashtable");
                     doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                     doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
-                    doAfterVisit(new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor());
+                    doAfterVisit(new org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor());
                     return hashtable.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                 }
                 return super.visitExpression(elem, ctx);

--- a/src/test/resources/recipes/NestedPreconditionsRecipe.java
+++ b/src/test/resources/recipes/NestedPreconditionsRecipe.java
@@ -44,6 +44,7 @@ public class NestedPreconditionsRecipe extends Recipe {
                     maybeAddImport("java.util.Hashtable");
                     doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                     doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
+                    doAfterVisit(new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor());
                     return hashtable.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                 }
                 return super.visitExpression(elem, ctx);

--- a/src/test/resources/recipes/ShouldAddImportsRecipes.java
+++ b/src/test/resources/recipes/ShouldAddImportsRecipes.java
@@ -64,6 +64,7 @@ public final class ShouldAddImportsRecipes extends Recipe {
                         maybeAddImport("java.util.Objects");
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                         doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
+                        doAfterVisit(new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                     }
                     return super.visitMethodInvocation(elem, ctx);
@@ -100,6 +101,7 @@ public final class ShouldAddImportsRecipes extends Recipe {
                         maybeRemoveImport("java.util.Objects");
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                         doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
+                        doAfterVisit(new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor());
                         return isis.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1));
                     }
                     return super.visitMethodInvocation(elem, ctx);
@@ -137,6 +139,7 @@ public final class ShouldAddImportsRecipes extends Recipe {
                         maybeRemoveImport("java.util.Objects.hash");
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                         doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
+                        doAfterVisit(new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                     }
                     return super.visitMethodInvocation(elem, ctx);

--- a/src/test/resources/recipes/ShouldAddImportsRecipes.java
+++ b/src/test/resources/recipes/ShouldAddImportsRecipes.java
@@ -64,7 +64,7 @@ public final class ShouldAddImportsRecipes extends Recipe {
                         maybeAddImport("java.util.Objects");
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                         doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
-                        doAfterVisit(new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                     }
                     return super.visitMethodInvocation(elem, ctx);
@@ -101,7 +101,7 @@ public final class ShouldAddImportsRecipes extends Recipe {
                         maybeRemoveImport("java.util.Objects");
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                         doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
-                        doAfterVisit(new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor());
                         return isis.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1));
                     }
                     return super.visitMethodInvocation(elem, ctx);
@@ -139,7 +139,7 @@ public final class ShouldAddImportsRecipes extends Recipe {
                         maybeRemoveImport("java.util.Objects.hash");
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                         doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
-                        doAfterVisit(new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                     }
                     return super.visitMethodInvocation(elem, ctx);

--- a/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
+++ b/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
@@ -59,7 +59,7 @@ public final class ShouldSupportNestedClassesRecipes extends Recipe {
                     if ((matcher = before.matcher(getCursor())).find()) {
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                         doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
-                        doAfterVisit(new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                     }
                     return super.visitBinary(elem, ctx);
@@ -94,7 +94,7 @@ public final class ShouldSupportNestedClassesRecipes extends Recipe {
                     if ((matcher = before.matcher(getCursor())).find()) {
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                         doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
-                        doAfterVisit(new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor());
+                        doAfterVisit(new org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                     }
                     return super.visitBinary(elem, ctx);

--- a/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
+++ b/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
@@ -59,6 +59,7 @@ public final class ShouldSupportNestedClassesRecipes extends Recipe {
                     if ((matcher = before.matcher(getCursor())).find()) {
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                         doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
+                        doAfterVisit(new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                     }
                     return super.visitBinary(elem, ctx);
@@ -93,6 +94,7 @@ public final class ShouldSupportNestedClassesRecipes extends Recipe {
                     if ((matcher = before.matcher(getCursor())).find()) {
                         doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                         doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
+                        doAfterVisit(new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor());
                         return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                     }
                     return super.visitBinary(elem, ctx);

--- a/src/test/resources/recipes/UseStringIsEmptyRecipe.java
+++ b/src/test/resources/recipes/UseStringIsEmptyRecipe.java
@@ -35,6 +35,7 @@ public class UseStringIsEmptyRecipe extends Recipe {
                 if ((matcher = before.matcher(getCursor())).find()) {
                     doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                     doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
+                    doAfterVisit(new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor());
                     return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                 }
                 return super.visitBinary(elem, ctx);

--- a/src/test/resources/recipes/UseStringIsEmptyRecipe.java
+++ b/src/test/resources/recipes/UseStringIsEmptyRecipe.java
@@ -35,7 +35,7 @@ public class UseStringIsEmptyRecipe extends Recipe {
                 if ((matcher = before.matcher(getCursor())).find()) {
                     doAfterVisit(new org.openrewrite.java.ShortenFullyQualifiedTypeReferences().getVisitor());
                     doAfterVisit(new org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor());
-                    doAfterVisit(new org.openrewrite.staticanalysis.SimplifyBooleanExpression().getVisitor());
+                    doAfterVisit(new org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor());
                     return after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0));
                 }
                 return super.visitBinary(elem, ctx);


### PR DESCRIPTION
## What's changed?
We call `SimplifyBooleanExpression` after visit.

## What's your motivation?
Replacements such as this one take two arguments, and have to be null safe depending on those arguments.
```java
private static class EqualsIgnoreCase {
    @BeforeTemplate
    boolean before(String s, String other) {
        return StringUtils.equalsIgnoreCase(s, other);
    }

    @AfterTemplate
    boolean after(String s, String other) {
        return (s == null && other == null || s != null && s.equalsIgnoreCase(other));
    }
}
```
When the above is passed a literal as second argument, it looks odd to do `"other" == null`.
With this do after visit we simplify those expressions again for easier recipe definition and better end result.

Fixes https://github.com/openrewrite/rewrite-templating/issues/28

## Any additional context
Requires
- [ ] https://github.com/openrewrite/rewrite-static-analysis/pull/154

- https://github.com/openrewrite/rewrite-templating/issues/28
- https://github.com/openrewrite/rewrite-templating/pull/29
