### PR TITLE
Use simpler nested class recipe name

### DIFF
--- a/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
@@ -390,10 +390,11 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
                                 String outerClassName = className.substring(className.lastIndexOf('.') + 1);
                                 out.write("public final class " + outerClassName + " extends Recipe {\n");
 
+                                String simpleInputOuterFQN = inputOuterFQN.substring(inputOuterFQN.lastIndexOf('.') + 1);
                                 out.write("\n" +
                                         "    @Override\n" +
                                         "    public String getDisplayName() {\n" +
-                                        "        return \"Refaster recipes for `" + inputOuterFQN + "`\";\n" +
+                                        "        return \"`" + simpleInputOuterFQN + "` Refaster recipes\";\n" +
                                         "    }\n" +
                                         "\n" +
                                         "    @Override\n" +

--- a/src/test/resources/recipes/MultipleDereferencesRecipes.java
+++ b/src/test/resources/recipes/MultipleDereferencesRecipes.java
@@ -18,7 +18,7 @@ public final class MultipleDereferencesRecipes extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Refaster recipes for `foo.MultipleDereferences`";
+        return "`MultipleDereferences` Refaster recipes";
     }
 
     @Override

--- a/src/test/resources/recipes/ShouldAddImportsRecipes.java
+++ b/src/test/resources/recipes/ShouldAddImportsRecipes.java
@@ -21,7 +21,7 @@ public final class ShouldAddImportsRecipes extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Refaster recipes for `foo.ShouldAddImports`";
+        return "`ShouldAddImports` Refaster recipes";
     }
 
     @Override

--- a/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
+++ b/src/test/resources/recipes/ShouldSupportNestedClassesRecipes.java
@@ -18,7 +18,7 @@ public final class ShouldSupportNestedClassesRecipes extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Refaster recipes for `foo.ShouldSupportNestedClasses`";
+        return "`ShouldSupportNestedClasses` Refaster recipes";
     }
 
     @Override


### PR DESCRIPTION
## What's changed?
Use input class simple name for display name of wrapping outer recipe.

## What's your motivation?
Quite repetitive when viewed in the platform, and harder to spot & search for.
https://app.moderne.io/recipes/org.openrewrite.java.migrate.apache.commons.lang.ApacheCommonsStringUtilsRecipes
![image](https://github.com/openrewrite/rewrite-templating/assets/1027334/6ebd80d1-632b-4f68-a956-0f54497b517c)
