### PR TITLE
Generate fully qualified references into template code

### DIFF
--- a/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/RefasterTemplateProcessor.java
@@ -27,10 +27,7 @@ import com.sun.tools.javac.tree.TreeMaker;
 import com.sun.tools.javac.tree.TreeScanner;
 import com.sun.tools.javac.util.Context;
 import org.jetbrains.annotations.Nullable;
-import org.openrewrite.java.template.internal.ImportDetector;
-import org.openrewrite.java.template.internal.JavacResolution;
-import org.openrewrite.java.template.internal.Permit;
-import org.openrewrite.java.template.internal.UsedMethodDetector;
+import org.openrewrite.java.template.internal.*;
 import org.openrewrite.java.template.internal.permit.Parent;
 import sun.misc.Unsafe;
 
@@ -323,8 +320,6 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
                                 if (beforeImports.contains(import_) && afterImports.contains(import_)) {
                                 } else if (beforeImports.contains(import_)) {
                                     recipe.append("                    maybeRemoveImport(\"" + import_ + "\");\n");
-                                } else if (afterImports.contains(import_)) {
-                                    recipe.append("                    maybeAddImport(\"" + import_ + "\");\n");
                                 }
                             }
                             beforeImports = staticImports.entrySet().stream()
@@ -345,8 +340,6 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
                                 if (beforeImports.contains(import_) && afterImports.contains(import_)) {
                                 } else if (beforeImports.contains(import_)) {
                                     recipe.append("                    maybeRemoveImport(\"" + import_ + "\");\n");
-                                } else if (afterImports.contains(import_)) {
-                                    recipe.append("                    maybeAddImport(\"" + import_.substring(0, dot) + "\", \"" + import_.substring(dot + 1) + "\");\n");
                                 }
                             }
                             if (parameters.isEmpty()) {
@@ -588,13 +581,13 @@ public class RefasterTemplateProcessor extends AbstractProcessor {
 
         JCTree.JCStatement statement = method.getBody().getStatements().get(0);
         if (statement instanceof JCTree.JCReturn) {
-            builder.append(((JCTree.JCReturn) statement).getExpression().toString());
+            builder.append(FQNPretty.toString(((JCTree.JCReturn) statement).getExpression()));
         } else if (statement instanceof JCTree.JCThrow) {
-            String string = statement.toString();
+            String string = FQNPretty.toString(statement);
             builder.append("{ ").append(string).append(" }");
         } else {
-            String string = statement.toString();
-            builder.append(string, 0, string.length() - 1);
+            String string = FQNPretty.toString(statement);
+            builder.append(string);
         }
         return builder.toString();
     }

--- a/src/main/java/org/openrewrite/java/template/internal/FQNPretty.java
+++ b/src/main/java/org/openrewrite/java/template/internal/FQNPretty.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.template.internal;
+
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.Pretty;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+
+public class FQNPretty extends Pretty {
+    private FQNPretty(Writer writer) {
+        super(writer, false);
+    }
+
+    public static String toString(JCTree tree) {
+        StringWriter writer = new StringWriter();
+        try {
+            new FQNPretty(writer).printExpr(tree);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return writer.toString();
+    }
+
+    @Override
+    public void visitIdent(JCTree.JCIdent jcIdent) {
+        try {
+            if (jcIdent.sym.getQualifiedName().toString().startsWith("java.lang.")) {
+                print(jcIdent.name);
+            } else {
+                print(jcIdent.sym.getQualifiedName());
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/src/test/resources/recipes/NestedPreconditionsRecipe.java
+++ b/src/test/resources/recipes/NestedPreconditionsRecipe.java
@@ -34,18 +34,17 @@ public class NestedPreconditionsRecipe extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
 
-            Supplier<JavaTemplate> hashMap = memoize(() -> JavaTemplate.compile(this, "hashMap", (JavaTemplate.F1<?, ?>) (@Primitive Integer size) -> new HashMap(size)).build());
+            Supplier<JavaTemplate> hashMap = memoize(() -> JavaTemplate.compile(this, "hashMap", (JavaTemplate.F1<?, ?>) (@Primitive Integer size) -> new java.util.HashMap(size)).build());
 
-            Supplier<JavaTemplate> linkedHashMap = memoize(() -> JavaTemplate.compile(this, "linkedHashMap", (JavaTemplate.F1<?, ?>) (@Primitive Integer size) -> new LinkedHashMap(size)).build());
+            Supplier<JavaTemplate> linkedHashMap = memoize(() -> JavaTemplate.compile(this, "linkedHashMap", (JavaTemplate.F1<?, ?>) (@Primitive Integer size) -> new java.util.LinkedHashMap(size)).build());
 
-            Supplier<JavaTemplate> hashtable= memoize(() -> JavaTemplate.compile(this, "hashtable", (JavaTemplate.F1<?, ?>) (@Primitive Integer size) -> new Hashtable(size)).build());
+            Supplier<JavaTemplate> hashtable= memoize(() -> JavaTemplate.compile(this, "hashtable", (JavaTemplate.F1<?, ?>) (@Primitive Integer size) -> new java.util.Hashtable(size)).build());
 
             @Override
             public J visitExpression(Expression elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
                 if ((matcher = matcher(hashMap, getCursor())).find()) {
                     maybeRemoveImport("java.util.HashMap");
-                    maybeAddImport("java.util.Hashtable");
                     return embed(
                             apply(hashtable, getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                             getCursor(),
@@ -54,7 +53,6 @@ public class NestedPreconditionsRecipe extends Recipe {
                 }
                 if ((matcher = matcher(linkedHashMap, getCursor())).find()) {
                     maybeRemoveImport("java.util.LinkedHashMap");
-                    maybeAddImport("java.util.Hashtable");
                     return embed(
                             apply(hashtable, getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                             getCursor(),

--- a/src/test/resources/recipes/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_after.java
+++ b/src/test/resources/recipes/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_after.java
@@ -4,8 +4,7 @@ import org.openrewrite.java.*;
 public class ShouldAddClasspathRecipes$UnqualifiedRecipe$1_after {
     public static JavaTemplate.Builder getTemplate(JavaVisitor<?> visitor) {
         return JavaTemplate
-                .builder("LoggerFactory.getLogger(#{any(java.lang.String)})")
-                .javaParser(JavaParser.fromJavaVersion().classpath("slf4j-api"))
-                .imports("org.slf4j.LoggerFactory");
+                .builder("org.slf4j.LoggerFactory.getLogger(#{any(java.lang.String)})")
+                .javaParser(JavaParser.fromJavaVersion().classpath("slf4j-api"));
     }
 }

--- a/src/test/resources/recipes/ShouldAddImportsRecipes.java
+++ b/src/test/resources/recipes/ShouldAddImportsRecipes.java
@@ -59,13 +59,12 @@ public final class ShouldAddImportsRecipes extends Recipe {
 
                 Supplier<JavaTemplate> before = memoize(() -> JavaTemplate.compile(this, "before", (JavaTemplate.F1<?, ?>) (String s) -> String.valueOf(s)).build());
 
-                Supplier<JavaTemplate> after= memoize(() -> JavaTemplate.compile(this, "after", (JavaTemplate.F1<?, ?>) (String s) -> Objects.toString(s)).build());
+                Supplier<JavaTemplate> after= memoize(() -> JavaTemplate.compile(this, "after", (JavaTemplate.F1<?, ?>) (String s) -> java.util.Objects.toString(s)).build());
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = matcher(before, getCursor())).find()) {
-                        maybeAddImport("java.util.Objects");
                         return embed(
                                 apply(after, getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
@@ -98,7 +97,7 @@ public final class ShouldAddImportsRecipes extends Recipe {
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
 
-                Supplier<JavaTemplate> equals = memoize(() -> JavaTemplate.compile(this, "equals", (JavaTemplate.F2<?, ?, ?>) (@Primitive Integer a, @Primitive Integer b) -> Objects.equals(a, b)).build());
+                Supplier<JavaTemplate> equals = memoize(() -> JavaTemplate.compile(this, "equals", (JavaTemplate.F2<?, ?, ?>) (@Primitive Integer a, @Primitive Integer b) -> java.util.Objects.equals(a, b)).build());
 
                 Supplier<JavaTemplate> compareZero = memoize(() -> JavaTemplate.compile(this, "compareZero", (@Primitive Integer a, @Primitive Integer b) -> Integer.compare(a, b) == 0).build());
 


### PR DESCRIPTION
This allows avoiding conflicts and also no longer requires using `maybeAddImport()`. Instead this will be handled by `ShortenFullyQualifiedTypeReferences` which is part of `AbstractRefasterJavaVisitor`.
