### PR TITLE
Print messages once, as to not flood console

### DIFF
--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -730,8 +730,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                 @Override
                 public void visitIdent(JCTree.JCIdent jcIdent) {
                     if (jcIdent.sym != null
-                        && jcIdent.sym.packge().getQualifiedName().contentEquals("com.google.errorprone.refaster")
-                        && !jcIdent.sym.getSimpleName().contentEquals("Refaster")) {
+                        && jcIdent.sym.packge().getQualifiedName().contentEquals("com.google.errorprone.refaster")) {
                         printNoteOnce(jcIdent.type.tsym.getQualifiedName() + " is not supported", template);
                         valid = false;
                     }

--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -739,14 +739,6 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
             return valid;
         }
 
-        private final Set<String> printedMessages = new HashSet<>();
-
-        private void printNoteOnce(String message, JCTree.JCMethodDecl template) {
-            if (printedMessages.add(message)) {
-                processingEnv.getMessager().printMessage(Kind.NOTE, message, template.sym);
-            }
-        }
-
         public void beforeTemplate(JCTree.JCMethodDecl method) {
             beforeTemplates.add(method);
         }
@@ -771,6 +763,14 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
             return true;
         }
 
+    }
+
+    private final Set<String> printedMessages = new HashSet<>();
+
+    private void printNoteOnce(String message, JCTree.JCMethodDecl template) {
+        if (printedMessages.add(message)) {
+            processingEnv.getMessager().printMessage(Kind.NOTE, message, template.sym);
+        }
     }
 
     private static List<JCTree.JCAnnotation> getTemplateAnnotations(MethodTree method, Predicate<String> typePredicate) {

--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -129,10 +129,13 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                     String templateCode = copy.toString().trim();
 
                     for (JCTree.JCMethodDecl template : descriptor.beforeTemplates) {
+                        Set<Type> thrown = template.thrown.stream().map(exp -> exp.type).collect(Collectors.toSet());
                         for (Symbol anImport : ImportDetector.imports(template)) {
                             if (anImport instanceof Symbol.ClassSymbol) {
-                                imports.computeIfAbsent(template, k -> new TreeSet<>())
-                                        .add(anImport.getQualifiedName().toString().replace('$', '.'));
+                                if (!thrown.contains(anImport.type)) {
+                                    imports.computeIfAbsent(template, k -> new TreeSet<>())
+                                            .add(anImport.getQualifiedName().toString().replace('$', '.'));
+                                }
                             } else if (anImport instanceof Symbol.VarSymbol || anImport instanceof Symbol.MethodSymbol) {
                                 staticImports.computeIfAbsent(template, k -> new TreeSet<>())
                                         .add(anImport.owner.getQualifiedName().toString().replace('$', '.') + '.' + anImport.flatName().toString());
@@ -142,9 +145,12 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                         }
                     }
                     for (Symbol anImport : ImportDetector.imports(descriptor.afterTemplate)) {
+                        Set<Type> thrown = descriptor.afterTemplate.thrown.stream().map(exp -> exp.type).collect(Collectors.toSet());
                         if (anImport instanceof Symbol.ClassSymbol) {
-                            imports.computeIfAbsent(descriptor.afterTemplate, k -> new TreeSet<>())
-                                    .add(anImport.getQualifiedName().toString().replace('$', '.'));
+                            if (!thrown.contains(anImport.type)) {
+                                imports.computeIfAbsent(descriptor.afterTemplate, k -> new TreeSet<>())
+                                        .add(anImport.getQualifiedName().toString().replace('$', '.'));
+                            }
                         } else if (anImport instanceof Symbol.VarSymbol || anImport instanceof Symbol.MethodSymbol) {
                             staticImports.computeIfAbsent(descriptor.afterTemplate, k -> new TreeSet<>())
                                     .add(anImport.owner.getQualifiedName().toString().replace('$', '.') + '.' + anImport.flatName().toString());

--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -129,13 +129,10 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                     String templateCode = copy.toString().trim();
 
                     for (JCTree.JCMethodDecl template : descriptor.beforeTemplates) {
-                        Set<Type> thrown = template.thrown.stream().map(exp -> exp.type).collect(Collectors.toSet());
                         for (Symbol anImport : ImportDetector.imports(template)) {
                             if (anImport instanceof Symbol.ClassSymbol) {
-                                if (!thrown.contains(anImport.type)) {
-                                    imports.computeIfAbsent(template, k -> new TreeSet<>())
-                                            .add(anImport.getQualifiedName().toString().replace('$', '.'));
-                                }
+                                imports.computeIfAbsent(template, k -> new TreeSet<>())
+                                        .add(anImport.getQualifiedName().toString().replace('$', '.'));
                             } else if (anImport instanceof Symbol.VarSymbol || anImport instanceof Symbol.MethodSymbol) {
                                 staticImports.computeIfAbsent(template, k -> new TreeSet<>())
                                         .add(anImport.owner.getQualifiedName().toString().replace('$', '.') + '.' + anImport.flatName().toString());
@@ -145,12 +142,9 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                         }
                     }
                     for (Symbol anImport : ImportDetector.imports(descriptor.afterTemplate)) {
-                        Set<Type> thrown = descriptor.afterTemplate.thrown.stream().map(exp -> exp.type).collect(Collectors.toSet());
                         if (anImport instanceof Symbol.ClassSymbol) {
-                            if (!thrown.contains(anImport.type)) {
-                                imports.computeIfAbsent(descriptor.afterTemplate, k -> new TreeSet<>())
-                                        .add(anImport.getQualifiedName().toString().replace('$', '.'));
-                            }
+                            imports.computeIfAbsent(descriptor.afterTemplate, k -> new TreeSet<>())
+                                    .add(anImport.getQualifiedName().toString().replace('$', '.'));
                         } else if (anImport instanceof Symbol.VarSymbol || anImport instanceof Symbol.MethodSymbol) {
                             staticImports.computeIfAbsent(descriptor.afterTemplate, k -> new TreeSet<>())
                                     .add(anImport.owner.getQualifiedName().toString().replace('$', '.') + '.' + anImport.flatName().toString());

--- a/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
@@ -47,6 +47,7 @@ class RefasterTemplateProcessorTest {
           .withClasspath(classpath())
           .compile(JavaFileObjects.forResource("refaster/" + recipeName + ".java"));
         assertThat(compilation).succeeded();
+        assertThat(compilation).hadNoteCount(0);
         compilation.generatedSourceFiles().forEach(System.out::println);
         assertThat(compilation)
           .generatedSourceFile("foo/" + recipeName + "Recipe")
@@ -55,10 +56,10 @@ class RefasterTemplateProcessorTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
-//      "ShouldSupportNestedClasses",
+      "ShouldSupportNestedClasses",
       "ShouldAddImports",
-//      "MultipleDereferences",
-//      "Matching",
+      "MultipleDereferences",
+      "Matching",
     })
     void nestedRecipes(String recipeName) {
         Compilation compilation = javac()
@@ -66,6 +67,7 @@ class RefasterTemplateProcessorTest {
           .withClasspath(classpath())
           .compile(JavaFileObjects.forResource("refaster/" + recipeName + ".java"));
         assertThat(compilation).succeeded();
+        assertThat(compilation).hadNoteCount(0);
         compilation.generatedSourceFiles().forEach(System.out::println);
         assertThat(compilation) // Recipes (plural)
           .generatedSourceFile("foo/" + recipeName + "Recipes")

--- a/src/test/resources/refaster/MatchingRecipes.java
+++ b/src/test/resources/refaster/MatchingRecipes.java
@@ -34,7 +34,7 @@ import java.util.*;
 import static org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor.EmbeddingOption.*;
 
 
-public final class MatchingRecipes extends Recipe {
+public class MatchingRecipes extends Recipe {
     @Override
     public String getDisplayName() {
         return "Static analysis";

--- a/src/test/resources/refaster/MultipleDereferencesRecipes.java
+++ b/src/test/resources/refaster/MultipleDereferencesRecipes.java
@@ -37,7 +37,7 @@ import java.nio.file.Files;
 import java.io.IOException;
 import java.nio.file.Path;
 
-public final class MultipleDereferencesRecipes extends Recipe {
+public class MultipleDereferencesRecipes extends Recipe {
     @Override
     public String getDisplayName() {
         return "`MultipleDereferences` Refaster recipes";

--- a/src/test/resources/refaster/MultipleDereferencesRecipes.java
+++ b/src/test/resources/refaster/MultipleDereferencesRecipes.java
@@ -34,7 +34,6 @@ import java.util.*;
 import static org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor.EmbeddingOption.*;
 
 import java.nio.file.Files;
-import java.io.IOException;
 import java.nio.file.Path;
 
 public class MultipleDereferencesRecipes extends Recipe {
@@ -93,7 +92,6 @@ public class MultipleDereferencesRecipes extends Recipe {
             };
             return Preconditions.check(
                     Preconditions.and(
-                            new UsesType<>("java.io.IOException", true),
                             new UsesType<>("java.nio.file.Files", true),
                             new UsesType<>("java.nio.file.Path", true),
                             new UsesMethod<>("java.nio.file.Files delete(..)")

--- a/src/test/resources/refaster/MultipleDereferencesRecipes.java
+++ b/src/test/resources/refaster/MultipleDereferencesRecipes.java
@@ -34,6 +34,7 @@ import java.util.*;
 import static org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor.EmbeddingOption.*;
 
 import java.nio.file.Files;
+import java.io.IOException;
 import java.nio.file.Path;
 
 public class MultipleDereferencesRecipes extends Recipe {
@@ -92,6 +93,7 @@ public class MultipleDereferencesRecipes extends Recipe {
             };
             return Preconditions.check(
                     Preconditions.and(
+                            new UsesType<>("java.io.IOException", true),
                             new UsesType<>("java.nio.file.Files", true),
                             new UsesType<>("java.nio.file.Path", true),
                             new UsesMethod<>("java.nio.file.Files delete(..)")

--- a/src/test/resources/refaster/ShouldSupportNestedClassesRecipes.java
+++ b/src/test/resources/refaster/ShouldSupportNestedClassesRecipes.java
@@ -34,7 +34,7 @@ import java.util.*;
 import static org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor.EmbeddingOption.*;
 
 
-public final class ShouldSupportNestedClassesRecipes extends Recipe {
+public class ShouldSupportNestedClassesRecipes extends Recipe {
     @Override
     public String getDisplayName() {
         return "`ShouldSupportNestedClasses` Refaster recipes";
@@ -95,7 +95,7 @@ public final class ShouldSupportNestedClassesRecipes extends Recipe {
     }
 
     @NonNullApi
-    static class AnotherClassRecipe extends Recipe {
+    public static class AnotherClassRecipe extends Recipe {
 
         @Override
         public String getDisplayName() {


### PR DESCRIPTION
## What's changed?
- Only print notes once
- Assert there's no messages in tests
- Fix and enable disabled tests

## What's your motivation?
As per #5 I was looking to add this to error-prone-support, but noticed we flood the console with repeated messages there, mostly pending #21.

## Any additional context
- #5 
- #21 
- https://github.com/openrewrite/rewrite-migrate-java/commit/4bfadd20f38ec86ccbe80aaa77789c23d3ec3cd7