### PR TITLE
Allow other annotation processors to process too

### DIFF
--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -101,8 +101,8 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                 maybeGenerateTemplateSources(jcCompilationUnit);
             }
         }
-
-        return true;
+        // Give other annotation processors a chance to process the same annotations, for dual use of Refaster templates
+        return false;
     }
 
     void maybeGenerateTemplateSources(JCCompilationUnit cu) {

--- a/src/main/java/org/openrewrite/java/template/processor/TemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/TemplateProcessor.java
@@ -136,7 +136,7 @@ public class TemplateProcessor extends TypeAwareProcessor {
                             inputStream.read(templateSourceBytes);
 
                             String templateSource = new String(templateSourceBytes);
-                            templateSource = templateSource.replace("\"", "\\\"");
+                            templateSource = templateSource.replace("\\", "\\\\").replace("\"", "\\\"");
 
                             for (Map.Entry<Integer, JCTree.JCVariableDecl> paramPos : parameterPositions.descendingMap().entrySet()) {
                                 JCTree.JCVariableDecl param = paramPos.getValue();


### PR DESCRIPTION
## What's changed?
Return `true` from `boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv)`.

## What's your motivation?
Needed to play well with Picnic/error-prone-support, as their own processor wants to create `.refaster` files from the same Refaster templates.

## Any additional context
> Processes a set of annotation types on type elements originating from the prior round and returns whether or not these annotation types are claimed by this processor. If true is returned, the annotation types are claimed and subsequent processors will not be asked to process them; if false is returned, the annotation types are unclaimed and subsequent processors may be asked to process them. A processor may always return the same boolean value or may vary the result based on chosen criteria.
The input set will be empty if the processor supports "*" and the root elements have no annotations. A Processor must gracefully handle an empty set of annotations.
`public abstract boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv);`
