### PR TITLE
Skip Class generics

### DIFF
--- a/src/test/java/com/google/errorprone/refaster/Refaster.java
+++ b/src/test/java/com/google/errorprone/refaster/Refaster.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.refaster;
+
+public class Refaster {
+    public static <T> T anyOf(T... expressions) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
@@ -56,8 +56,8 @@ class RefasterTemplateProcessorTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
+      "OrElseGetGet",
       "RefasterAnyOf",
-      "OrOrElseThrow",
     })
     void skipRecipeGeneration(String recipeName){
         Compilation compilation = javac()

--- a/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
@@ -49,10 +49,23 @@ class RefasterTemplateProcessorTest {
           .compile(JavaFileObjects.forResource("refaster/" + recipeName + ".java"));
         assertThat(compilation).succeeded();
         assertThat(compilation).hadNoteCount(0);
-        compilation.generatedSourceFiles().forEach(System.out::println);
         assertThat(compilation)
           .generatedSourceFile("foo/" + recipeName + "Recipe")
           .hasSourceEquivalentTo(JavaFileObjects.forResource("refaster/" + recipeName + "Recipe.java"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "RefasterAnyOf",
+      "OrOrElseThrow",
+    })
+    void skipRecipeGeneration(String recipeName){
+        Compilation compilation = javac()
+          .withProcessors(new RefasterTemplateProcessor())
+          .withClasspath(classpath())
+          .compile(JavaFileObjects.forResource("refaster/" + recipeName + ".java"));
+        assertThat(compilation).succeeded();
+        assert compilation.generatedSourceFiles().isEmpty();
     }
 
     @ParameterizedTest
@@ -69,7 +82,6 @@ class RefasterTemplateProcessorTest {
           .compile(JavaFileObjects.forResource("refaster/" + recipeName + ".java"));
         assertThat(compilation).succeeded();
         assertThat(compilation).hadNoteCount(0);
-        compilation.generatedSourceFiles().forEach(System.out::println);
         assertThat(compilation) // Recipes (plural)
           .generatedSourceFile("foo/" + recipeName + "Recipes")
           .hasSourceEquivalentTo(JavaFileObjects.forResource("refaster/" + recipeName + "Recipes.java"));
@@ -90,7 +102,7 @@ class RefasterTemplateProcessorTest {
     // As per https://github.com/google/auto/blob/auto-value-1.10.2/factory/src/test/java/com/google/auto/factory/processor/AutoFactoryProcessorTest.java#L99
     static File fileForClass(Class<?> c) {
         URL url = c.getProtectionDomain().getCodeSource().getLocation();
-        assert url.getProtocol().equals("file");
+        assert url.getProtocol().equals("file") || url.getProtocol().equals("jrt") : "Unexpected URL: " + url;
         return new File(url.getPath());
     }
 }

--- a/src/test/resources/refaster/OrElseGetGet.java
+++ b/src/test/resources/refaster/OrElseGetGet.java
@@ -19,16 +19,14 @@ import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import java.util.Optional;
 
-class OrOrElseThrow<T> {
+class OrElseGetGet<T> {
     @BeforeTemplate
-    @SuppressWarnings("NullAway")
     T before(Optional<T> o1, Optional<T> o2) {
-        return o1.orElseGet(() -> o2.orElseThrow());
+        return o1.orElseGet(() -> o2.get());
     }
 
     @AfterTemplate
-    @SuppressWarnings("NullAway")
     T after(Optional<T> o1, Optional<T> o2) {
-        return o1.or(() -> o2).orElseThrow();
+        return o1.orElseGet(o2::get);
     }
 }

--- a/src/test/resources/refaster/OrOrElseThrow.java
+++ b/src/test/resources/refaster/OrOrElseThrow.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package foo;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import java.util.Optional;
+
+class OrOrElseThrow<T> {
+    @BeforeTemplate
+    @SuppressWarnings("NullAway")
+    T before(Optional<T> o1, Optional<T> o2) {
+        return o1.orElseGet(() -> o2.orElseThrow());
+    }
+
+    @AfterTemplate
+    @SuppressWarnings("NullAway")
+    T after(Optional<T> o1, Optional<T> o2) {
+        return o1.or(() -> o2).orElseThrow();
+    }
+}

--- a/src/test/resources/refaster/RefasterAnyOf.java
+++ b/src/test/resources/refaster/RefasterAnyOf.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package foo;
+
+import com.google.errorprone.refaster.Refaster;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import org.openrewrite.java.template.RecipeDescriptor;
+
+@RecipeDescriptor(
+        name = "Use `String.isEmpty()`",
+        description = "Use `String#isEmpty()` instead of String length comparison.",
+        tags = {"sast", "strings"}
+)
+public class RefasterAnyOf {
+    @BeforeTemplate
+    boolean before(String s) {
+        return Refaster.anyOf(s.length() < 1, s.length() == 0);
+    }
+
+    @AfterTemplate
+    boolean after(String s) {
+        return s.isEmpty();
+    }
+}


### PR DESCRIPTION
## What's changed?
Add tests to show we ought to skip both Refaster (ok) and Class generics (not ok).

## What's your motivation?
OrOrElseThrows is found in error-prone-support, but breaks template generation there due to a compilation error.

## Anything in particular you'd like reviewers to focus on?
There's also the issue that the test template only works on Java 11.
I wonder if we should use that as minimum for rewrite-templating.

## Have you considered any alternatives or workarounds?
Not quite sure yet how to catch and resolve this compilation error when using Java 11:
```
Compilation produced the following diagnostics:
Note: Generics are currently not supported
/home/tim/Documents/workspace/openrewrite/rewrite-templating/out/test/resources/refaster/OrOrElseThrow.java:26: error: incompatible types: bad return type in lambda expression
        return o1.orElseGet(() -> o2.orElseThrow());
                                                ^
    T cannot be converted to T
No files were generated.
```