### PR TITLE
Reduce warnings by generating JavaDoc

### DIFF
--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -176,13 +176,15 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                     String after = descriptor.afterTemplate.getName().toString();
 
                     StringBuilder recipe = new StringBuilder();
+                    String refasterRuleClassName = classDecl.sym.fullname.toString().substring(classDecl.sym.packge().fullname.length() + 1);
+                    recipe.append("/**\n * OpenRewrite recipe created for Refaster template `").append(refasterRuleClassName).append("`.\n */\n");
                     String recipeName = templateFqn.substring(templateFqn.lastIndexOf('.') + 1);
                     recipe.append("@NonNullApi\n");
                     recipe.append(descriptor.classDecl.sym.outermostClass() == descriptor.classDecl.sym ?
                             "public class " : "public static class ").append(recipeName).append(" extends Recipe {\n");
                     recipe.append("\n");
                     recipe.append(recipeDescriptor(classDecl,
-                            "Refaster template `" + classDecl.sym.fullname.toString().substring(classDecl.sym.packge().fullname.length() + 1) + '`',
+                            "Refaster template `" + refasterRuleClassName + '`',
                             "Recipe created for the following Refaster template:\\n```java\\n" + escape(templateCode) + "\\n```\\n."
                     ));
                     recipe.append("    @Override\n");
@@ -333,6 +335,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                             }
 
                             if (outerClassRequired) {
+                                out.write("/**\n * OpenRewrite recipes created for Refaster template `" + inputOuterFQN + "`.\n */\n");
                                 String outerClassName = className.substring(className.lastIndexOf('.') + 1);
                                 out.write("public class " + outerClassName + " extends Recipe {\n");
                                 out.write(recipeDescriptor(classDecl,

--- a/src/main/java/org/openrewrite/java/template/processor/TemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/TemplateProcessor.java
@@ -215,8 +215,8 @@ public class TemplateProcessor extends TypeAwareProcessor {
                                 }
 
                                 out.write("\n");
-                                out.write("public class " + templateFqn.substring(templateFqn.lastIndexOf('.') + 1) + " {\n");
-                                out.write("    public static JavaTemplate.Builder getTemplate() {\n");
+                                out.write("class " + templateFqn.substring(templateFqn.lastIndexOf('.') + 1) + " {\n");
+                                out.write("    static JavaTemplate.Builder getTemplate() {\n");
                                 out.write("        return JavaTemplate\n");
                                 out.write("                .builder(\"" + templateSource + "\")");
 

--- a/src/test/resources/template/ParameterReuseRecipe$1_before.java
+++ b/src/test/resources/template/ParameterReuseRecipe$1_before.java
@@ -16,8 +16,8 @@
 package foo;
 import org.openrewrite.java.*;
 
-public class ParameterReuseRecipe$1_before {
-    public static JavaTemplate.Builder getTemplate() {
+class ParameterReuseRecipe$1_before {
+    static JavaTemplate.Builder getTemplate() {
         return JavaTemplate
                 .builder("#{s:any(java.lang.String)}.equals(#{s})");
     }

--- a/src/test/resources/template/ShouldAddClasspathRecipe$FullyQualifiedRecipe$1_after.java
+++ b/src/test/resources/template/ShouldAddClasspathRecipe$FullyQualifiedRecipe$1_after.java
@@ -16,8 +16,8 @@
 package foo;
 import org.openrewrite.java.*;
 
-public class ShouldAddClasspathRecipes$FullyQualifiedRecipe$1_after {
-    public static JavaTemplate.Builder getTemplate() {
+class ShouldAddClasspathRecipes$FullyQualifiedRecipe$1_after {
+    static JavaTemplate.Builder getTemplate() {
         return JavaTemplate
                 .builder("org.slf4j.LoggerFactory.getLogger(#{message:any(java.lang.String)})")
                 .javaParser(JavaParser.fromJavaVersion().classpath("slf4j-api"));

--- a/src/test/resources/template/ShouldAddClasspathRecipe$FullyQualifiedRecipe$1_before.java
+++ b/src/test/resources/template/ShouldAddClasspathRecipe$FullyQualifiedRecipe$1_before.java
@@ -16,8 +16,8 @@
 package foo;
 import org.openrewrite.java.*;
 
-public class ShouldAddClasspathRecipes$FullyQualifiedRecipe$1_before {
-    public static JavaTemplate.Builder getTemplate() {
+class ShouldAddClasspathRecipes$FullyQualifiedRecipe$1_before {
+    static JavaTemplate.Builder getTemplate() {
         return JavaTemplate
                 .builder("System.out.println(#{message:any(java.lang.String)})");
     }

--- a/src/test/resources/template/ShouldAddClasspathRecipe$PrimitiveRecipe$1_after.java
+++ b/src/test/resources/template/ShouldAddClasspathRecipe$PrimitiveRecipe$1_after.java
@@ -16,8 +16,8 @@
 package foo;
 import org.openrewrite.java.*;
 
-public class ShouldAddClasspathRecipes$PrimitiveRecipe$1_after {
-    public static JavaTemplate.Builder getTemplate() {
+class ShouldAddClasspathRecipes$PrimitiveRecipe$1_after {
+    static JavaTemplate.Builder getTemplate() {
         return JavaTemplate
                 .builder("System.out.print(#{i:any(int)})");
     }

--- a/src/test/resources/template/ShouldAddClasspathRecipe$PrimitiveRecipe$1_before.java
+++ b/src/test/resources/template/ShouldAddClasspathRecipe$PrimitiveRecipe$1_before.java
@@ -16,8 +16,8 @@
 package foo;
 import org.openrewrite.java.*;
 
-public class ShouldAddClasspathRecipes$PrimitiveRecipe$1_before {
-    public static JavaTemplate.Builder getTemplate() {
+class ShouldAddClasspathRecipes$PrimitiveRecipe$1_before {
+    static JavaTemplate.Builder getTemplate() {
         return JavaTemplate
                 .builder("System.out.println(#{i:any(int)})");
     }

--- a/src/test/resources/template/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_after.java
+++ b/src/test/resources/template/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_after.java
@@ -16,8 +16,8 @@
 package foo;
 import org.openrewrite.java.*;
 
-public class ShouldAddClasspathRecipes$UnqualifiedRecipe$1_after {
-    public static JavaTemplate.Builder getTemplate() {
+class ShouldAddClasspathRecipes$UnqualifiedRecipe$1_after {
+    static JavaTemplate.Builder getTemplate() {
         return JavaTemplate
                 .builder("org.slf4j.LoggerFactory.getLogger(#{message:any(java.lang.String)})")
                 .javaParser(JavaParser.fromJavaVersion().classpath("slf4j-api"));

--- a/src/test/resources/template/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_before.java
+++ b/src/test/resources/template/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_before.java
@@ -16,8 +16,8 @@
 package foo;
 import org.openrewrite.java.*;
 
-public class ShouldAddClasspathRecipes$UnqualifiedRecipe$1_before {
-    public static JavaTemplate.Builder getTemplate() {
+class ShouldAddClasspathRecipes$UnqualifiedRecipe$1_before {
+    static JavaTemplate.Builder getTemplate() {
         return JavaTemplate
                 .builder("System.out.println(#{message:any(java.lang.String)})");
     }


### PR DESCRIPTION
## What's changed?
Also generate a line of JavaDoc for classes.

## What's your motivation?
Reduce warnings on use in error-prone-support.

## Any additional context
- #5