### PR TITLE
Restore public modifiers with javadoc

### DIFF
--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -690,7 +690,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
             for (JCTree member : classDecl.getMembers()) {
                 if (member instanceof JCTree.JCMethodDecl && !beforeTemplates.contains(member) && member != afterTemplate) {
                     for (JCTree.JCAnnotation annotation : getTemplateAnnotations(((JCTree.JCMethodDecl) member), UNSUPPORTED_ANNOTATIONS::contains)) {
-                        printNoteOnce("The @" + annotation.annotationType + " is currently not supported", classDecl.sym);
+                        printNoteOnce("@" + annotation.annotationType + " is currently not supported", classDecl.sym);
                         valid = false;
                     }
                 }
@@ -711,13 +711,13 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
             boolean valid = true;
             // TODO: support all Refaster method-level annotations
             for (JCTree.JCAnnotation annotation : getTemplateAnnotations(template, UNSUPPORTED_ANNOTATIONS::contains)) {
-                printNoteOnce("The @" + annotation.annotationType + " is currently not supported", classDecl.sym);
+                printNoteOnce("@" + annotation.annotationType + " is currently not supported", classDecl.sym);
                 valid = false;
             }
             // TODO: support all Refaster parameter-level annotations
             for (JCTree.JCVariableDecl parameter : template.getParameters()) {
                 for (JCTree.JCAnnotation annotation : getTemplateAnnotations(parameter, UNSUPPORTED_ANNOTATIONS::contains)) {
-                    printNoteOnce("The @" + annotation.annotationType + " annotation is currently not supported", classDecl.sym);
+                    printNoteOnce("@" + annotation.annotationType + " is currently not supported", classDecl.sym);
                     valid = false;
                 }
                 if (parameter.vartype instanceof ParameterizedTypeTree || parameter.vartype.type instanceof Type.TypeVar) {
@@ -741,7 +741,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                 public void visitIdent(JCTree.JCIdent jcIdent) {
                     if (jcIdent.sym != null
                         && jcIdent.sym.packge().getQualifiedName().contentEquals("com.google.errorprone.refaster")) {
-                        printNoteOnce(jcIdent.type.tsym.getQualifiedName() + " is not supported", classDecl.sym);
+                        printNoteOnce(jcIdent.type.tsym.getQualifiedName() + " is currently not supported", classDecl.sym);
                         valid = false;
                     }
                 }

--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -690,7 +690,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
             for (JCTree member : classDecl.getMembers()) {
                 if (member instanceof JCTree.JCMethodDecl && !beforeTemplates.contains(member) && member != afterTemplate) {
                     for (JCTree.JCAnnotation annotation : getTemplateAnnotations(((JCTree.JCMethodDecl) member), UNSUPPORTED_ANNOTATIONS::contains)) {
-                        printNoteOnce("The @" + annotation.annotationType + " is currently not supported", ((JCTree.JCMethodDecl) member).sym);
+                        printNoteOnce("The @" + annotation.annotationType + " is currently not supported", classDecl.sym);
                         valid = false;
                     }
                 }
@@ -711,22 +711,22 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
             boolean valid = true;
             // TODO: support all Refaster method-level annotations
             for (JCTree.JCAnnotation annotation : getTemplateAnnotations(template, UNSUPPORTED_ANNOTATIONS::contains)) {
-                printNoteOnce("The @" + annotation.annotationType + " is currently not supported", template.sym);
+                printNoteOnce("The @" + annotation.annotationType + " is currently not supported", classDecl.sym);
                 valid = false;
             }
             // TODO: support all Refaster parameter-level annotations
             for (JCTree.JCVariableDecl parameter : template.getParameters()) {
                 for (JCTree.JCAnnotation annotation : getTemplateAnnotations(parameter, UNSUPPORTED_ANNOTATIONS::contains)) {
-                    printNoteOnce("The @" + annotation.annotationType + " annotation is currently not supported", template.sym);
+                    printNoteOnce("The @" + annotation.annotationType + " annotation is currently not supported", classDecl.sym);
                     valid = false;
                 }
                 if (parameter.vartype instanceof ParameterizedTypeTree || parameter.vartype.type instanceof Type.TypeVar) {
-                    printNoteOnce("Generics are currently not supported", template.sym);
+                    printNoteOnce("Generics are currently not supported", classDecl.sym);
                     valid = false;
                 }
             }
             if (template.restype instanceof ParameterizedTypeTree || template.restype.type instanceof Type.TypeVar) {
-                printNoteOnce("Generics are currently not supported", template.sym);
+                printNoteOnce("Generics are currently not supported", classDecl.sym);
                 valid = false;
             }
             valid &= new TreeScanner() {
@@ -741,7 +741,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                 public void visitIdent(JCTree.JCIdent jcIdent) {
                     if (jcIdent.sym != null
                         && jcIdent.sym.packge().getQualifiedName().contentEquals("com.google.errorprone.refaster")) {
-                        printNoteOnce(jcIdent.type.tsym.getQualifiedName() + " is not supported", template.sym);
+                        printNoteOnce(jcIdent.type.tsym.getQualifiedName() + " is not supported", classDecl.sym);
                         valid = false;
                     }
                 }
@@ -777,7 +777,11 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
 
     private final Set<String> printedMessages = new HashSet<>();
 
-    private void printNoteOnce(String message, Symbol symbol) {
+    /**
+     * @param message The message to print
+     * @param symbol The symbol to attach the message to; printed as clickable link to file
+     */
+    private void printNoteOnce(String message, Symbol.ClassSymbol symbol) {
         if (printedMessages.add(message)) {
             processingEnv.getMessager().printMessage(Kind.NOTE, message, symbol);
         }

--- a/src/main/java/org/openrewrite/java/template/processor/TemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/TemplateProcessor.java
@@ -215,8 +215,10 @@ public class TemplateProcessor extends TypeAwareProcessor {
                                 }
 
                                 out.write("\n");
-                                out.write("class " + templateFqn.substring(templateFqn.lastIndexOf('.') + 1) + " {\n");
-                                out.write("    static JavaTemplate.Builder getTemplate() {\n");
+                                out.write("/**\n * OpenRewrite `" + templateName.getValue() + "` template created for  `" + templateFqn.split("_")[0] + "`.\n */\n");
+                                out.write("public class " + templateFqn.substring(templateFqn.lastIndexOf('.') + 1) + " {\n");
+                                out.write("    /**\n * @return `JavaTemplate` to match or replace.\n */\n");
+                                out.write("    public static JavaTemplate.Builder getTemplate() {\n");
                                 out.write("        return JavaTemplate\n");
                                 out.write("                .builder(\"" + templateSource + "\")");
 

--- a/src/main/java/org/openrewrite/java/template/processor/TemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/TemplateProcessor.java
@@ -217,7 +217,7 @@ public class TemplateProcessor extends TypeAwareProcessor {
                                 out.write("\n");
                                 out.write("/**\n * OpenRewrite `" + templateName.getValue() + "` template created for  `" + templateFqn.split("_")[0] + "`.\n */\n");
                                 out.write("public class " + templateFqn.substring(templateFqn.lastIndexOf('.') + 1) + " {\n");
-                                out.write("    /**\n * @return `JavaTemplate` to match or replace.\n */\n");
+                                out.write("    /**\n     * @return `JavaTemplate` to match or replace.\n     */\n");
                                 out.write("    public static JavaTemplate.Builder getTemplate() {\n");
                                 out.write("        return JavaTemplate\n");
                                 out.write("                .builder(\"" + templateSource + "\")");

--- a/src/test/resources/template/ParameterReuseRecipe$1_before.java
+++ b/src/test/resources/template/ParameterReuseRecipe$1_before.java
@@ -16,8 +16,8 @@
 package foo;
 import org.openrewrite.java.*;
 
-class ParameterReuseRecipe$1_before {
-    static JavaTemplate.Builder getTemplate() {
+public class ParameterReuseRecipe$1_before {
+    public static JavaTemplate.Builder getTemplate() {
         return JavaTemplate
                 .builder("#{s:any(java.lang.String)}.equals(#{s})");
     }

--- a/src/test/resources/template/ShouldAddClasspathRecipe$FullyQualifiedRecipe$1_after.java
+++ b/src/test/resources/template/ShouldAddClasspathRecipe$FullyQualifiedRecipe$1_after.java
@@ -16,8 +16,8 @@
 package foo;
 import org.openrewrite.java.*;
 
-class ShouldAddClasspathRecipes$FullyQualifiedRecipe$1_after {
-    static JavaTemplate.Builder getTemplate() {
+public class ShouldAddClasspathRecipes$FullyQualifiedRecipe$1_after {
+    public static JavaTemplate.Builder getTemplate() {
         return JavaTemplate
                 .builder("org.slf4j.LoggerFactory.getLogger(#{message:any(java.lang.String)})")
                 .javaParser(JavaParser.fromJavaVersion().classpath("slf4j-api"));

--- a/src/test/resources/template/ShouldAddClasspathRecipe$FullyQualifiedRecipe$1_before.java
+++ b/src/test/resources/template/ShouldAddClasspathRecipe$FullyQualifiedRecipe$1_before.java
@@ -16,8 +16,8 @@
 package foo;
 import org.openrewrite.java.*;
 
-class ShouldAddClasspathRecipes$FullyQualifiedRecipe$1_before {
-    static JavaTemplate.Builder getTemplate() {
+public class ShouldAddClasspathRecipes$FullyQualifiedRecipe$1_before {
+    public static JavaTemplate.Builder getTemplate() {
         return JavaTemplate
                 .builder("System.out.println(#{message:any(java.lang.String)})");
     }

--- a/src/test/resources/template/ShouldAddClasspathRecipe$PrimitiveRecipe$1_after.java
+++ b/src/test/resources/template/ShouldAddClasspathRecipe$PrimitiveRecipe$1_after.java
@@ -16,8 +16,8 @@
 package foo;
 import org.openrewrite.java.*;
 
-class ShouldAddClasspathRecipes$PrimitiveRecipe$1_after {
-    static JavaTemplate.Builder getTemplate() {
+public class ShouldAddClasspathRecipes$PrimitiveRecipe$1_after {
+    public static JavaTemplate.Builder getTemplate() {
         return JavaTemplate
                 .builder("System.out.print(#{i:any(int)})");
     }

--- a/src/test/resources/template/ShouldAddClasspathRecipe$PrimitiveRecipe$1_before.java
+++ b/src/test/resources/template/ShouldAddClasspathRecipe$PrimitiveRecipe$1_before.java
@@ -16,8 +16,8 @@
 package foo;
 import org.openrewrite.java.*;
 
-class ShouldAddClasspathRecipes$PrimitiveRecipe$1_before {
-    static JavaTemplate.Builder getTemplate() {
+public class ShouldAddClasspathRecipes$PrimitiveRecipe$1_before {
+    public static JavaTemplate.Builder getTemplate() {
         return JavaTemplate
                 .builder("System.out.println(#{i:any(int)})");
     }

--- a/src/test/resources/template/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_after.java
+++ b/src/test/resources/template/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_after.java
@@ -16,8 +16,8 @@
 package foo;
 import org.openrewrite.java.*;
 
-class ShouldAddClasspathRecipes$UnqualifiedRecipe$1_after {
-    static JavaTemplate.Builder getTemplate() {
+public class ShouldAddClasspathRecipes$UnqualifiedRecipe$1_after {
+    public static JavaTemplate.Builder getTemplate() {
         return JavaTemplate
                 .builder("org.slf4j.LoggerFactory.getLogger(#{message:any(java.lang.String)})")
                 .javaParser(JavaParser.fromJavaVersion().classpath("slf4j-api"));

--- a/src/test/resources/template/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_before.java
+++ b/src/test/resources/template/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_before.java
@@ -16,8 +16,8 @@
 package foo;
 import org.openrewrite.java.*;
 
-class ShouldAddClasspathRecipes$UnqualifiedRecipe$1_before {
-    static JavaTemplate.Builder getTemplate() {
+public class ShouldAddClasspathRecipes$UnqualifiedRecipe$1_before {
+    public static JavaTemplate.Builder getTemplate() {
         return JavaTemplate
                 .builder("System.out.println(#{message:any(java.lang.String)})");
     }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
- Resttore public modifiers for template classes, as needed on Java 11+
- Add JavaDoc on template classes, to reduce warnings on error-prone- support
- Always print clickable link with notes

### Before
```
[INFO] /error-prone-support/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSortedMapRules.java:[24,16] Generics are currently not supported
[INFO] com.google.errorprone.refaster.Refaster is not supported
[INFO] The @UseImportPolicy is currently not supported
[INFO] /error-prone-support/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/LongStreamRules.java:[66,25] The @Placeholder is currently not supported
[INFO] The @AlsoNegation is currently not supported
[INFO] The @DoNotCall is currently not supported
[INFO] The @Repeated annotation is currently not supported
[INFO] The @Matches annotation is currently not supported
```

### After
```
[INFO] /error-prone-support/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSortedMapRules.java:[24,16] Generics are currently not supported
[INFO] /error-prone-support/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/EqualityRules.java:[85,16] com.google.errorprone.refaster.Refaster is currently not supported
[INFO] /error-prone-support/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MockitoRules.java:[26,16] @UseImportPolicy is currently not supported
[INFO] /error-prone-support/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/LongStreamRules.java:[64,19] @Placeholder is currently not supported
[INFO] /error-prone-support/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java:[72,16] @AlsoNegation is currently not supported
[INFO] /error-prone-support/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TestNGToAssertJRules.java:[80,16] @DoNotCall is currently not supported
[INFO] /error-prone-support/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/WebClientRules.java:[179,16] @Repeated is currently not supported
[INFO] /error-prone-support/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java:[1585,16] @Matches is currently not supported
```


## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Makes things work on Java 11 and in error-prone-support
