### PR TITLE
Missing template classpath entry for parameters

### DIFF
--- a/src/main/java/org/openrewrite/java/template/internal/ClasspathJarNameDetector.java
+++ b/src/main/java/org/openrewrite/java/template/internal/ClasspathJarNameDetector.java
@@ -23,11 +23,9 @@ import com.sun.tools.javac.tree.TreeScanner;
 import javax.tools.JavaFileObject;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public class ClasspathJarNameDetector {
 
@@ -37,8 +35,13 @@ public class ClasspathJarNameDetector {
      *
      * @return The list of imports to add.
      */
-    public static String classpathFor(JCTree input, List<Symbol> imports) {
-        Set<String> jarNames = new LinkedHashSet<>();
+    public static Set<String> classpathFor(JCTree input, List<Symbol> imports) {
+        Set<String> jarNames = new LinkedHashSet<String>() {
+            @Override
+            public boolean add(String s) {
+                return s != null && super.add(s);
+            }
+        };
 
         for (Symbol anImport : imports) {
             jarNames.add(jarNameFor(anImport));
@@ -57,11 +60,7 @@ public class ClasspathJarNameDetector {
             }
         }.scan(input);
 
-        return jarNames.stream()
-                .filter(Objects::nonNull)
-                .map(jarName -> '"' + jarName + '"')
-                .sorted()
-                .collect(Collectors.joining(", "));
+        return jarNames;
     }
 
 

--- a/src/main/java/org/openrewrite/java/template/internal/TemplateCode.java
+++ b/src/main/java/org/openrewrite/java/template/internal/TemplateCode.java
@@ -25,7 +25,8 @@ import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.util.*;
-import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.joining;
 
 public class TemplateCode {
 
@@ -40,14 +41,18 @@ public class TemplateCode {
                     .append(writer.toString().replace("\\", "\\\\").replace("\"", "\\\""))
                     .append("\")");
             if (!printer.imports.isEmpty()) {
-                builder.append("\n    .imports(").append(printer.imports.stream().map(i -> '"' + i + '"').collect(Collectors.joining(", "))).append(")");
+                builder.append("\n    .imports(").append(printer.imports.stream().map(i -> '"' + i + '"').collect(joining(", "))).append(")");
             }
             if (!printer.staticImports.isEmpty()) {
-                builder.append("\n    .staticImports(").append(printer.staticImports.stream().map(i -> '"' + i + '"').collect(Collectors.joining(", "))).append(")");
+                builder.append("\n    .staticImports(").append(printer.staticImports.stream().map(i -> '"' + i + '"').collect(joining(", "))).append(")");
             }
             List<Symbol> imports = ImportDetector.imports(tree);
-            String classpath = ClasspathJarNameDetector.classpathFor(tree, imports);
-            if (!classpath.isEmpty()) {
+            Set<String> jarNames = ClasspathJarNameDetector.classpathFor(tree, imports);
+            for (JCTree.JCVariableDecl parameter : parameters) {
+                jarNames.addAll(ClasspathJarNameDetector.classpathFor(parameter, ImportDetector.imports(parameter)));
+            }
+            if (!jarNames.isEmpty()) {
+                String classpath = jarNames.stream().map(jarName -> '"' + jarName + '"').sorted().collect(joining(", "));
                 builder.append("\n    .javaParser(JavaParser.fromJavaVersion().classpath(").append(classpath).append("))");
             }
             return builder.toString();

--- a/src/main/java/org/openrewrite/java/template/processor/TemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/TemplateProcessor.java
@@ -145,15 +145,6 @@ public class TemplateProcessor extends TypeAwareProcessor {
                                 out.write("package " + classDecl.sym.packge().toString() + ";\n");
                                 out.write("import org.openrewrite.java.*;\n");
 
-                                for (JCTree.JCVariableDecl parameter : parameters) {
-                                    if (parameter.type.tsym instanceof Symbol.ClassSymbol) {
-                                        String paramType = parameter.type.tsym.getQualifiedName().toString();
-                                        if (!paramType.startsWith("java.lang") && !"Array".equals(paramType)) {
-                                            out.write("import " + paramType + ";\n");
-                                        }
-                                    }
-                                }
-
                                 out.write("\n");
                                 out.write("/**\n * OpenRewrite `" + templateName.getValue() + "` template created for {@code " + templateFqn.split("_")[0] + "}.\n */\n");
                                 String templateClassName = templateFqn.substring(templateFqn.lastIndexOf('.') + 1);

--- a/src/test/java/org/openrewrite/java/template/TemplateProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/template/TemplateProcessorTest.java
@@ -61,5 +61,8 @@ class TemplateProcessorTest {
         assertThat(compilation)
           .generatedSourceFile("template/LoggerRecipe$1_logger")
           .hasSourceEquivalentTo(JavaFileObjects.forResource("template/LoggerRecipe$1_logger.java"));
+        assertThat(compilation)
+          .generatedSourceFile("template/LoggerRecipe$1_info")
+          .hasSourceEquivalentTo(JavaFileObjects.forResource("template/LoggerRecipe$1_info.java"));
     }
 }

--- a/src/test/resources/template/LoggerRecipe$1_info.java
+++ b/src/test/resources/template/LoggerRecipe$1_info.java
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 package template;
+import org.openrewrite.java.*;
 
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.JavaTemplate;
-import org.openrewrite.java.template.Semantics;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+@SuppressWarnings("all")
+public class LoggerRecipe$1_info {
+    public LoggerRecipe$1_info() {}
 
-public class LoggerRecipe {
-    JavaIsoVisitor visitor = new JavaIsoVisitor<ExecutionContext>() {
-        JavaTemplate.Builder logger = Semantics.expression(this, "logger", (String s) -> LoggerFactory.getLogger(s));
-        JavaTemplate.Builder info = Semantics.statement(this, "info", (Logger l, String s) -> l.info(s));
-    };
+    public static JavaTemplate.Builder getTemplate() {
+        return JavaTemplate
+                .builder("(#{l:any(org.slf4j.Logger)}).info(#{s:any(java.lang.String)})")
+                .imports("org.slf4j.Logger")
+                .javaParser(JavaParser.fromJavaVersion().classpath("slf4j-api"));
+    }
 }

--- a/src/test/resources/template/LoggerRecipe$1_info.java
+++ b/src/test/resources/template/LoggerRecipe$1_info.java
@@ -22,8 +22,7 @@ public class LoggerRecipe$1_info {
 
     public static JavaTemplate.Builder getTemplate() {
         return JavaTemplate
-                .builder("(#{l:any(org.slf4j.Logger)}).info(#{s:any(java.lang.String)})")
-                .imports("org.slf4j.Logger")
+                .builder("#{l:any(org.slf4j.Logger)}.info(#{s:any(java.lang.String)})")
                 .javaParser(JavaParser.fromJavaVersion().classpath("slf4j-api"));
     }
 }


### PR DESCRIPTION
Turns out we were indeed missing classpath entries, but only for the parameters, as seen in:
https://github.com/openrewrite/rewrite-micrometer/actions/workflows/ci.yml

TemplatCode.process gets the body passed in separately from the parameters; and we only looked at the body for classpath entries and imports. Now we also add classpath entries for input parameters (but no imports).