### PR TITLE
Fix compilation error around throws on EPS

### DIFF
--- a/src/main/java/org/openrewrite/java/template/internal/TemplateCode.java
+++ b/src/main/java/org/openrewrite/java/template/internal/TemplateCode.java
@@ -37,7 +37,10 @@ public class TemplateCode {
             StringBuilder builder = new StringBuilder("JavaTemplate\n");
             builder
                     .append("    .builder(\"")
-                    .append(writer.toString().replace("\\", "\\\\").replace("\"", "\\\""))
+                    .append(writer.toString()
+                            .replace("\\", "\\\\")
+                            .replace("\"", "\\\"")
+                            .replaceAll("\\R", " "))
                     .append("\")");
             if (!printer.imports.isEmpty()) {
                 builder.append("\n    .imports(").append(printer.imports.stream().map(i -> '"' + i + '"').collect(Collectors.joining(", "))).append(")");

--- a/src/main/java/org/openrewrite/java/template/internal/TemplateCode.java
+++ b/src/main/java/org/openrewrite/java/template/internal/TemplateCode.java
@@ -40,7 +40,7 @@ public class TemplateCode {
                     .append(writer.toString()
                             .replace("\\", "\\\\")
                             .replace("\"", "\\\"")
-                            .replaceAll("\\R", " "))
+                            .replaceAll("\\R", "\\\\n"))
                     .append("\")");
             if (!printer.imports.isEmpty()) {
                 builder.append("\n    .imports(").append(printer.imports.stream().map(i -> '"' + i + '"').collect(Collectors.joining(", "))).append(")");

--- a/src/test/java/org/openrewrite/java/template/TemplateProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/template/TemplateProcessorTest.java
@@ -62,4 +62,13 @@ class TemplateProcessorTest {
           .generatedSourceFile("template/LoggerRecipe$1_logger")
           .hasSourceEquivalentTo(JavaFileObjects.forResource("template/LoggerRecipe$1_logger.java"));
     }
+
+    @Test
+    void throwNew() {
+        Compilation compilation = compile("template/ThrowNewRecipe.java", new TemplateProcessor());
+        assertThat(compilation).succeeded();
+        assertThat(compilation)
+          .generatedSourceFile("template/ThrowNewRecipe$1_template")
+          .hasSourceEquivalentTo(JavaFileObjects.forResource("template/ThrowNewRecipe$1_template.java"));
+    }
 }

--- a/src/test/resources/template/ThrowNewRecipe$1_template.java
+++ b/src/test/resources/template/ThrowNewRecipe$1_template.java
@@ -22,6 +22,6 @@ public class ThrowNewRecipe$1_template {
 
     public static JavaTemplate.Builder getTemplate() {
         return JavaTemplate
-                .builder("{     throw new IllegalArgumentException(#{s:any(java.lang.String)}); }");
+                .builder("{\n    throw new IllegalArgumentException(#{s:any(java.lang.String)});\n}");
     }
 }

--- a/src/test/resources/template/ThrowNewRecipe$1_template.java
+++ b/src/test/resources/template/ThrowNewRecipe$1_template.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package template;
+import org.openrewrite.java.*;
+
+@SuppressWarnings("all")
+public class ThrowNewRecipe$1_template {
+    public ThrowNewRecipe$1_template() {}
+
+    public static JavaTemplate.Builder getTemplate() {
+        return JavaTemplate
+                .builder("{     throw new IllegalArgumentException(#{s:any(java.lang.String)}); }");
+    }
+}

--- a/src/test/resources/template/ThrowNewRecipe.java
+++ b/src/test/resources/template/ThrowNewRecipe.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package template;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.template.Semantics;
+
+public class ThrowNewRecipe {
+    JavaIsoVisitor visitor = new JavaIsoVisitor<ExecutionContext>() {
+        JavaTemplate.Builder template = Semantics.expression(this, "template", (String s) -> {
+            throw new IllegalArgumentException(s);
+        });
+    };
+}


### PR DESCRIPTION
Before this change we produced the following, which does not compile due to the new lines in the String.
```java
public static JavaTemplate.Builder getTemplate() {
    return JavaTemplate
            .builder("{
            throw new AssertionError();
        }");
}
```