### PR TITLE
Don't skip embedOptions for parameterless recipes

### DIFF
--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -274,16 +274,16 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                                 embedOptions.add("SIMPLIFY_BOOLEANS");
                             }
 
-                            if (parameters.isEmpty()) {
-                                recipe.append("                    return embed(").append(after).append(".apply(getCursor(), elem.getCoordinates().replace()), getCursor(), ctx);\n");
-                            } else {
-                                recipe.append("                    return embed(\n");
-                                recipe.append("                            ").append(after).append(".apply(getCursor(), elem.getCoordinates().replace(), ").append(parameters).append("),\n");
-                                recipe.append("                            getCursor(),\n");
-                                recipe.append("                            ctx,\n");
-                                recipe.append("                            ").append(String.join(", ", embedOptions)).append("\n");
-                                recipe.append("                    );\n");
+                            recipe.append("                    return embed(\n");
+                            recipe.append("                            ").append(after).append(".apply(getCursor(), elem.getCoordinates().replace()");
+                            if (!parameters.isEmpty()) {
+                                recipe.append(", ").append(parameters);
                             }
+                            recipe.append("),\n");
+                            recipe.append("                            getCursor(),\n");
+                            recipe.append("                            ctx,\n");
+                            recipe.append("                            ").append(String.join(", ", embedOptions)).append("\n");
+                            recipe.append("                    );\n");
                             recipe.append("                }\n");
                         }
                         recipe.append("                return super.visit").append(methodSuffix).append("(elem, ctx);\n");

--- a/src/test/resources/refaster/MultipleDereferencesRecipes.java
+++ b/src/test/resources/refaster/MultipleDereferencesRecipes.java
@@ -178,7 +178,12 @@ public class MultipleDereferencesRecipes extends Recipe {
                 public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
-                        return embed(after.apply(getCursor(), elem.getCoordinates().replace()), getCursor(), ctx);
+                        return embed(
+                                after.apply(getCursor(), elem.getCoordinates().replace()),
+                                getCursor(),
+                                ctx,
+                                SHORTEN_NAMES, SIMPLIFY_BOOLEANS
+                        );
                     }
                     return super.visitBinary(elem, ctx);
                 }

--- a/src/test/resources/refaster/UnnamedPackageRecipe.java
+++ b/src/test/resources/refaster/UnnamedPackageRecipe.java
@@ -64,7 +64,12 @@ public class UnnamedPackageRecipe extends Recipe {
             public J visitExpression(Expression elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
                 if ((matcher = before.matcher(getCursor())).find()) {
-                    return embed(after.apply(getCursor(), elem.getCoordinates().replace()), getCursor(), ctx);
+                    return embed(
+                            after.apply(getCursor(), elem.getCoordinates().replace()),
+                            getCursor(),
+                            ctx,
+                            SHORTEN_NAMES
+                    );
                 }
                 return super.visitExpression(elem, ctx);
             }


### PR DESCRIPTION
Deduplicate the logic for creating the recipe code to avoid an inconcistency in how the embedOptions are used.

Fixes #66.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
