### PR TITLE
enforce UTF-8 resources on older JVMs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,8 @@ dependencies {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    // enforce reading resources as UTF-8 also on JDKs before Java 18
+    systemProperty("file.encoding", "UTF-8")
 }
 
 tasks.withType<Javadoc> {


### PR DESCRIPTION
Before Java 18 the default charset was platform dependent, which leads to failing tests on older JVMs with another default charset.

## What's changed?
For unit tests all resources are now read as UTF-8 via the system property file.encoding.

## What's your motivation?
Fixes #69.