### PR TITLE
Fix multiline values in `@RecipeDescriptor`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 .boot-releases
 out/
 .attach_pid*
+.DS_Store

--- a/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
@@ -37,6 +37,7 @@ class RefasterTemplateProcessorTest {
     @ParameterizedTest
     @ValueSource(strings = {
       "Arrays",
+      "CharacterEscapeAnnotation",
       "MethodThrows",
       "NestedPreconditions",
       "ParameterReuse",

--- a/src/test/resources/refaster/CharacterEscapeAnnotation.java
+++ b/src/test/resources/refaster/CharacterEscapeAnnotation.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package foo;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import org.openrewrite.java.template.RecipeDescriptor;
+
+@RecipeDescriptor(
+        name = "Multiline Annotation\nContains a newline character!",
+        description = "A multiline annotation.\nSupported here too!\n" +
+                      "It also supports escaped quotations: \"I think therefore I am\" - Descartes.\n" +
+                      "And escaped backslashes: C:\\Users\\JohnDoe\\Documents\\\n" +
+                      "And escaped tabs: \"This is a string with a tab character\t\".\n" +
+                      "And escaped carriage returns: \"This is a string with a carriage return character\r\".\n" +
+                      "And escaped form feeds: \"This is a string with a form feed character\f\".\n" +
+                      "And escaped backspace characters: \"This is a string with a backspace character\b\".\n" +
+                      "And escaped null characters: \"This is a string with a null character\0\".\n" +
+                      "And escaped octal characters: \"This is a string with an octal character\123\".\n" +
+                      "And escaped unicode characters: \"This is a string with a unicode character\u1234\".\n" +
+                      "And raw emoji: \"This is a string with an emoji😀\".\n" +
+                      "And emojis: \"This is a string with an emoji\uD83D\uDE00\".",
+        tags = {"tag1", "tag2", "tag with\nnewline character"}
+)
+public class CharacterEscapeAnnotation {
+
+    @BeforeTemplate
+    String before() {
+        return "The answer to life, the universe, and everything";
+    }
+
+    @AfterTemplate
+    String after() {
+        return "42";
+    }
+}

--- a/src/test/resources/refaster/CharacterEscapeAnnotationRecipe.java
+++ b/src/test/resources/refaster/CharacterEscapeAnnotationRecipe.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package foo;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.NonNullApi;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.search.*;
+import org.openrewrite.java.template.Primitive;
+import org.openrewrite.java.template.Semantics;
+import org.openrewrite.java.template.function.*;
+import org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor;
+import org.openrewrite.java.tree.*;
+
+import java.util.*;
+
+import static org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor.EmbeddingOption.*;
+
+
+/**
+ * OpenRewrite recipe created for Refaster template {@code MultilineAnnotation}.
+ */
+@SuppressWarnings("all")
+@NonNullApi
+public class CharacterEscapeAnnotationRecipe extends Recipe {
+
+    /**
+     * Instantiates a new instance.
+     */
+    public MultilineAnnotationRecipe() {}
+
+    @Override
+    public String getDisplayName() {
+        return "Multiline Annotation\nContains a newline character!";
+    }
+
+    @Override
+    public String getDescription() {
+        return "A multiline annotation.\nSupported here too!\nIt also supports escaped quotations: \"I think therefore I am\" - Descartes.\nAnd escaped backslashes: C:\\Users\\JohnDoe\\Documents\\\nAnd escaped tabs: \"This is a string with a tab character\t\".\nAnd escaped carriage returns: \"This is a string with a carriage return character\r\".\nAnd escaped form feeds: \"This is a string with a form feed character\f\".\nAnd escaped backspace characters: \"This is a string with a backspace character\b\".\nAnd escaped null characters: \"This is a string with a null character\u0000\".\nAnd escaped octal characters: \"This is a string with an octal characterS\".\nAnd escaped unicode characters: \"This is a string with a unicode character\u1234\".\nAnd raw emoji: \"This is a string with an emoji\uD83D\uDE00\".\nAnd emojis: \"This is a string with an emoji\uD83D\uDE00\".";
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return new HashSet<>(Arrays.asList("tag1", "tag2", "tag with\nnewline character"));
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
+            final JavaTemplate before = Semantics.expression(this, "before", () -> "The answer to life, the universe, and everything").build();
+            final JavaTemplate after = Semantics.expression(this, "after", () -> "42").build();
+
+            @Override
+            public J visitExpression(Expression elem, ExecutionContext ctx) {
+                JavaTemplate.Matcher matcher;
+                if ((matcher = before.matcher(getCursor())).find()) {
+                    return embed(
+                            after.apply(getCursor(), elem.getCoordinates().replace()),
+                            getCursor(),
+                            ctx,
+                            SHORTEN_NAMES
+                    );
+                }
+                return super.visitExpression(elem, ctx);
+            }
+
+        };
+        return javaVisitor;
+    }
+}


### PR DESCRIPTION
Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>

## What's changed?
<!-- A brief description of the changes in this pull request -->

Fixed the generated code from not properly escaping all special characters for Java.

This was done by using https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/StringEscapeUtils.html#escapeJava(java.lang.String)

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

Discovered this bug in https://github.com/openrewrite/rewrite-static-analysis/pull/252
This fixes it.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

I know that Jonathan's opinion is to try to minimize the number of third party libraries that openrewrite depends upon, but
given that the purpose of this codebase is to do text generation/manipulation, this library seems appropreate for the use-case.

Also, if this templating engine is ever used to generate code for other languages, the ability to escape those languages will likely also be appropreate.

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

I could copy-paste the escaping logic from `commons-text` into this codebase, but I figured using an industry standard library for this sort of thing
would better stand the test of time.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
