### PR TITLE
Generate statement templates as appropriate

### DIFF
--- a/src/main/java/org/openrewrite/java/template/internal/TemplateCode.java
+++ b/src/main/java/org/openrewrite/java/template/internal/TemplateCode.java
@@ -31,11 +31,15 @@ import static java.util.stream.Collectors.joining;
 
 public class TemplateCode {
 
-    public static <T extends JCTree> String process(T tree, List<JCTree.JCVariableDecl> parameters, boolean fullyQualified) {
+    public static <T extends JCTree> String process(T tree, List<JCTree.JCVariableDecl> parameters, boolean asStatement, boolean fullyQualified) {
         StringWriter writer = new StringWriter();
         TemplateCodePrinter printer = new TemplateCodePrinter(writer, parameters, fullyQualified);
         try {
-            printer.printExpr(tree);
+            if (asStatement) {
+                printer.printStat(tree);
+            } else {
+                printer.printExpr(tree);
+            }
             StringBuilder builder = new StringBuilder("JavaTemplate\n");
             builder
                     .append("    .builder(\"")

--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -768,7 +768,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                 tree = ((JCTree.JCReturn) tree).getExpression();
             }
 
-            String javaTemplateBuilder = TemplateCode.process(tree, method.getParameters(), true);
+            String javaTemplateBuilder = TemplateCode.process(tree, method.getParameters(), method.restype.type instanceof Type.JCVoidType, true);
             return TemplateCode.indent(javaTemplateBuilder, 16);
         }
 
@@ -808,7 +808,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                 }
             }.translate(copied);
 
-            String javaTemplateBuilder = TemplateCode.process(translated, method.getParameters(), true);
+            String javaTemplateBuilder = TemplateCode.process(translated, method.getParameters(), method.restype.type instanceof Type.JCVoidType, true);
             return TemplateCode.indent(javaTemplateBuilder, 16);
         }
 

--- a/src/main/java/org/openrewrite/java/template/processor/TemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/TemplateProcessor.java
@@ -138,7 +138,7 @@ public class TemplateProcessor extends TypeAwareProcessor {
                                 }
                             }
 
-                            String templateCode = TemplateCode.process(resolved.get(template.getBody()), parameters, false);
+                            String templateCode = TemplateCode.process(resolved.get(template.getBody()), parameters, "statement".equals(name), false);
 
                             Symbol.PackageSymbol pkg = classDecl.sym.packge();
                             JavaFileObject builderFile = processingEnv.getFiler().createSourceFile(templateFqn);

--- a/src/test/resources/refaster/MethodThrowsRecipe.java
+++ b/src/test/resources/refaster/MethodThrowsRecipe.java
@@ -59,10 +59,10 @@ public class MethodThrowsRecipe extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
             final JavaTemplate before = JavaTemplate
-                    .builder("java.nio.file.Files.readAllLines(#{path:any(java.nio.file.Path)}, java.nio.charset.StandardCharsets.UTF_8)")
+                    .builder("java.nio.file.Files.readAllLines(#{path:any(java.nio.file.Path)}, java.nio.charset.StandardCharsets.UTF_8);")
                     .build();
             final JavaTemplate after = JavaTemplate
-                    .builder("java.nio.file.Files.readAllLines(#{path:any(java.nio.file.Path)})")
+                    .builder("java.nio.file.Files.readAllLines(#{path:any(java.nio.file.Path)});")
                     .build();
 
             @Override

--- a/src/test/resources/refaster/MultipleDereferencesRecipes.java
+++ b/src/test/resources/refaster/MultipleDereferencesRecipes.java
@@ -88,10 +88,10 @@ public class MultipleDereferencesRecipes extends Recipe {
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
                 final JavaTemplate before = JavaTemplate
-                        .builder("java.nio.file.Files.delete(#{p:any(java.nio.file.Path)})")
+                        .builder("java.nio.file.Files.delete(#{p:any(java.nio.file.Path)});")
                         .build();
                 final JavaTemplate after = JavaTemplate
-                        .builder("java.nio.file.Files.delete(#{p:any(java.nio.file.Path)})")
+                        .builder("java.nio.file.Files.delete(#{p:any(java.nio.file.Path)});")
                         .build();
 
                 @Override


### PR DESCRIPTION
When a Refaster template method has a `void` return type the body should be matched against a statement, rather than an expression.
