### PR TITLE
Add import for nested search recipes

### DIFF
--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -122,6 +122,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
         Context context = javacProcessingEnv.getContext();
 
         new TreeScanner() {
+            boolean anySearchRecipe;
             final Map<TemplateDescriptor, Set<String>> imports = new HashMap<>();
             final Map<TemplateDescriptor, Set<String>> staticImports = new HashMap<>();
             final Map<String, String> recipes = new LinkedHashMap<>();
@@ -130,10 +131,9 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
             public void visitClassDef(JCTree.JCClassDecl classDecl) {
                 super.visitClassDef(classDecl);
 
-                boolean anySearchRecipe = false;
                 RuleDescriptor descriptor = getRuleDescriptor(classDecl, context, cu);
                 if (descriptor != null) {
-                    anySearchRecipe = descriptor.afterTemplate == null;
+                    anySearchRecipe |= descriptor.afterTemplate == null;
 
                     TreeMaker treeMaker = TreeMaker.instance(context).forToplevel(cu);
                     List<JCTree> membersWithoutConstructor = classDecl.getMembers().stream()

--- a/src/test/resources/refaster/ShouldAddImports.java
+++ b/src/test/resources/refaster/ShouldAddImports.java
@@ -80,4 +80,11 @@ public class ShouldAddImports {
             return exists(path);
         }
     }
+
+    public static class FindStringIsEmpty {
+        @BeforeTemplate
+        boolean before(String s) {
+            return s.isEmpty();
+        }
+    }
 }


### PR DESCRIPTION
The `SearchResult` import is also required when the search recipe is a nested one.

Fixes: #84
