### PR TITLE
Fix #86 - Refaster style recipes cannot match types that require transitive dependencies to be loaded

### DIFF
--- a/src/main/java/org/openrewrite/java/template/internal/TemplateCode.java
+++ b/src/main/java/org/openrewrite/java/template/internal/TemplateCode.java
@@ -61,8 +61,12 @@ public class TemplateCode {
                 jarNames.addAll(ClasspathJarNameDetector.classpathFor(parameter, ImportDetector.imports(parameter)));
             }
             if (!jarNames.isEmpty()) {
-                String classpath = jarNames.stream().map(jarName -> '"' + jarName + '"').sorted().collect(joining(", "));
-                builder.append("\n    .javaParser(JavaParser.fromJavaVersion().classpath(").append(classpath).append("))");
+                // It might be preferable to enumerate exactly the needed dependencies rather than the full classpath
+                // But this is expedient
+                // See https://github.com/openrewrite/rewrite-templating/issues/86
+                // String classpath = jarNames.stream().map(jarName -> '"' + jarName + '"').sorted().collect(joining(", "));
+                // builder.append("\n    .javaParser(JavaParser.fromJavaVersion().classpath(").append(classpath).append("))");
+                builder.append("\n    .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))");
             }
             return builder.toString();
         } catch (IOException e) {

--- a/src/test/java/org/openrewrite/java/template/TemplateProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/template/TemplateProcessorTest.java
@@ -22,8 +22,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.java.template.processor.TemplateProcessor;
 
-import java.nio.charset.StandardCharsets;
-
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static org.openrewrite.java.template.RefasterTemplateProcessorTest.*;
 

--- a/src/test/resources/refaster/EscapesRecipes.java
+++ b/src/test/resources/refaster/EscapesRecipes.java
@@ -88,11 +88,11 @@ public class EscapesRecipes extends Recipe {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
                 final JavaTemplate before = JavaTemplate
                         .builder("String.format(\"\\\"%s\\\"\", com.sun.tools.javac.util.Convert.quote(#{value:any(java.lang.String)}))")
-                        .javaParser(JavaParser.fromJavaVersion().classpath("tools"))
+                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
                         .build();
                 final JavaTemplate after = JavaTemplate
                         .builder("com.sun.tools.javac.util.Constants.format(#{value:any(java.lang.String)})")
-                        .javaParser(JavaParser.fromJavaVersion().classpath("tools"))
+                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
                         .build();
 
                 @Override

--- a/src/test/resources/template/LoggerRecipe$1_info.java
+++ b/src/test/resources/template/LoggerRecipe$1_info.java
@@ -23,6 +23,6 @@ public class LoggerRecipe$1_info {
     public static JavaTemplate.Builder getTemplate() {
         return JavaTemplate
                 .builder("#{l:any(org.slf4j.Logger)}.info(#{s:any(java.lang.String)})")
-                .javaParser(JavaParser.fromJavaVersion().classpath("slf4j-api"));
+                .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
     }
 }

--- a/src/test/resources/template/LoggerRecipe$1_logger.java
+++ b/src/test/resources/template/LoggerRecipe$1_logger.java
@@ -24,6 +24,6 @@ public class LoggerRecipe$1_logger {
         return JavaTemplate
                 .builder("LoggerFactory.getLogger(#{s:any(java.lang.String)})")
                 .imports("org.slf4j.LoggerFactory")
-                .javaParser(JavaParser.fromJavaVersion().classpath("slf4j-api"));
+                .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
     }
 }

--- a/src/test/resources/template/ShouldAddClasspathRecipe$FullyQualifiedRecipe$1_after.java
+++ b/src/test/resources/template/ShouldAddClasspathRecipe$FullyQualifiedRecipe$1_after.java
@@ -23,6 +23,6 @@ public class ShouldAddClasspathRecipes$FullyQualifiedRecipe$1_after {
     public static JavaTemplate.Builder getTemplate() {
         return JavaTemplate
                 .builder("org.slf4j.LoggerFactory.getLogger(#{message:any(java.lang.String)})")
-                .javaParser(JavaParser.fromJavaVersion().classpath("slf4j-api"));
+                .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
     }
 }

--- a/src/test/resources/template/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_after.java
+++ b/src/test/resources/template/ShouldAddClasspathRecipe$UnqualifiedRecipe$1_after.java
@@ -24,6 +24,6 @@ public class ShouldAddClasspathRecipes$UnqualifiedRecipe$1_after {
         return JavaTemplate
                 .builder("getLogger(#{message:any(java.lang.String)})")
                 .staticImports("org.slf4j.LoggerFactory.getLogger")
-                .javaParser(JavaParser.fromJavaVersion().classpath("slf4j-api"));
+                .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
     }
 }


### PR DESCRIPTION
See #86 