### PR TITLE
Troubleshoot mismatched AssertJ `AbstractStringAssert.isEqualTo("")`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:latest.release")
     testImplementation("org.junit.jupiter:junit-jupiter-params:latest.release")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:latest.release")
+    testImplementation("org.assertj:assertj-core:latest.release")
 }
 
 tasks.withType<Test> {

--- a/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
@@ -19,6 +19,7 @@ import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
+import org.assertj.core.api.AbstractStringAssert;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -45,6 +46,7 @@ class RefasterTemplateProcessorTest {
       "UseStringIsEmpty",
       "SimplifyBooleans",
       "FindListAdd",
+      "AbstractStringAssertStringIsEmpty"
     })
     void generateRecipe(String recipeName) {
         Compilation compilation = compileResource("refaster/" + recipeName + ".java");
@@ -133,7 +135,8 @@ class RefasterTemplateProcessorTest {
             fileForClass(org.openrewrite.Recipe.class),
             fileForClass(org.openrewrite.java.JavaTemplate.class),
             fileForClass(org.slf4j.Logger.class),
-            fileForClass(Primitive.class)
+            fileForClass(Primitive.class),
+            fileForClass(AbstractStringAssert.class)
           ))
           .compile(javaFileObject);
     }

--- a/src/test/resources/refaster/AbstractStringAssertStringIsEmpty.java
+++ b/src/test/resources/refaster/AbstractStringAssertStringIsEmpty.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package foo;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import org.assertj.core.api.AbstractStringAssert;
+
+public class AbstractStringAssertStringIsEmpty {
+
+    @BeforeTemplate
+    void before(AbstractStringAssert<?> stringAssert) {
+        stringAssert.isEqualTo("");
+    }
+
+    @AfterTemplate
+    void after(AbstractStringAssert<?> stringAssert) {
+        stringAssert.isEmpty();
+    }
+}

--- a/src/test/resources/refaster/AbstractStringAssertStringIsEmptyRecipe.java
+++ b/src/test/resources/refaster/AbstractStringAssertStringIsEmptyRecipe.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package foo;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.NonNullApi;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.search.*;
+import org.openrewrite.java.template.Primitive;
+import org.openrewrite.java.template.function.*;
+import org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor;
+import org.openrewrite.java.tree.*;
+
+import java.util.*;
+
+import static org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor.EmbeddingOption.*;
+
+/**
+ * OpenRewrite recipe created for Refaster template {@code AbstractStringAssertStringIsEmpty}.
+ */
+@SuppressWarnings("all")
+@NonNullApi
+public class AbstractStringAssertStringIsEmptyRecipe extends Recipe {
+
+    /**
+     * Instantiates a new instance.
+     */
+    public AbstractStringAssertStringIsEmptyRecipe() {}
+
+    @Override
+    public String getDisplayName() {
+        return "Refaster template `AbstractStringAssertStringIsEmpty`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Recipe created for the following Refaster template:\n```java\npublic class AbstractStringAssertStringIsEmpty {\n    \n    @BeforeTemplate()\n    void before(AbstractStringAssert<?> stringAssert) {\n        stringAssert.isEqualTo(\"\");\n    }\n    \n    @AfterTemplate()\n    void after(AbstractStringAssert<?> stringAssert) {\n        stringAssert.isEmpty();\n    }\n}\n```\n.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
+            final JavaTemplate before = JavaTemplate
+                    .builder("#{stringAssert:any(org.assertj.core.api.AbstractStringAssert<?>)}.isEqualTo(\"\");")
+                    .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                    .build();
+            final JavaTemplate after = JavaTemplate
+                    .builder("#{stringAssert:any(org.assertj.core.api.AbstractStringAssert<?>)}.isEmpty();")
+                    .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                    .build();
+
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
+                JavaTemplate.Matcher matcher;
+                if ((matcher = before.matcher(getCursor())).find()) {
+                    return embed(
+                            after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                            getCursor(),
+                            ctx,
+                            SHORTEN_NAMES
+                    );
+                }
+                return super.visitMethodInvocation(elem, ctx);
+            }
+
+        };
+        return Preconditions.check(
+                Preconditions.and(
+                        new UsesType<>("org.assertj.core.api.AbstractStringAssert", true),
+                        new UsesMethod<>("org.assertj.core.api.AbstractStringAssert isEqualTo(..)")
+                ),
+                javaVisitor
+        );
+    }
+}


### PR DESCRIPTION
This is a recipe that originates with Picnic: https://error-prone.picnic.tech/refasterrules/AssertJStringRules/#abstractstringassertstringisempty

At present it fails to convert this test case
```java
@Test
void convertsIsEqualToEmptyString() {
    rewriteRun(
      //language=java
      java(
        """
          import static org.assertj.core.api.Assertions.assertThat;
          class Test {
              void test() {
                  assertThat("test").isEqualTo("");
              }
          }
          """,
        """
          import static org.assertj.core.api.Assertions.assertThat;
          class Test {
              void test() {
                  assertThat("test").isEmpty();
              }
          }
          """
      )
    );
}
```

As discovered on
- https://github.com/openrewrite/rewrite-testing-frameworks/pull/527

Not yet sure if the fix should go into the generated recipe, or in the matchers used in the generated recipe. Figured log this as a pseudo issue to more easily see the generated recipe.