### PR TITLE
Match method overrides in precondition

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     signing
 
     id("nebula.maven-resolved-dependencies") version "17.3.2"
-    id("nebula.release") version "15.3.1"
+    id("com.netflix.nebula.release") version "19.0.10"
     id("io.github.gradle-nexus.publish-plugin") version "1.0.0"
 
     id("com.github.hierynomus.license") version "0.16.1"

--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -568,7 +568,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                             }
                             String methodName = method.name.toString();
                             methodName = methodName.equals("<init>") ? "<constructor>" : methodName;
-                            usesVisitors.add("new UsesMethod<>(\"" + method.owner.getQualifiedName().toString() + ' ' + methodName + "(..)\")");
+                            usesVisitors.add("new UsesMethod<>(\"" + method.owner.getQualifiedName().toString() + ' ' + methodName + "(..)\", true)");
                         }
 
                         preconditions.put(beforeTemplate.method.name.toString() + (arity == 1 ? "" : "$" + i), usesVisitors);

--- a/src/test/resources/refaster/ArraysRecipe.java
+++ b/src/test/resources/refaster/ArraysRecipe.java
@@ -84,7 +84,7 @@ public class ArraysRecipe extends Recipe {
 
         };
         return Preconditions.check(
-                new UsesMethod<>("java.lang.String join(..)"),
+                new UsesMethod<>("java.lang.String join(..)", true)
                 javaVisitor
         );
     }

--- a/src/test/resources/refaster/ArraysRecipe.java
+++ b/src/test/resources/refaster/ArraysRecipe.java
@@ -84,7 +84,7 @@ public class ArraysRecipe extends Recipe {
 
         };
         return Preconditions.check(
-                new UsesMethod<>("java.lang.String join(..)", true)
+                new UsesMethod<>("java.lang.String join(..)", true),
                 javaVisitor
         );
     }

--- a/src/test/resources/refaster/EscapesRecipes.java
+++ b/src/test/resources/refaster/EscapesRecipes.java
@@ -117,7 +117,7 @@ public class EscapesRecipes extends Recipe {
             return Preconditions.check(
                     Preconditions.and(
                             new UsesType<>("com.sun.tools.javac.util.Convert", true),
-                            new UsesMethod<>("java.lang.String format(..)", true)
+                            new UsesMethod<>("java.lang.String format(..)", true),
                             new UsesMethod<>("com.sun.tools.javac.util.Convert quote(..)", true)
                     ),
                     javaVisitor
@@ -174,7 +174,7 @@ public class EscapesRecipes extends Recipe {
 
             };
             return Preconditions.check(
-                    new UsesMethod<>("java.lang.String split(..)", true)
+                    new UsesMethod<>("java.lang.String split(..)", true),
                     javaVisitor
             );
         }

--- a/src/test/resources/refaster/EscapesRecipes.java
+++ b/src/test/resources/refaster/EscapesRecipes.java
@@ -117,7 +117,7 @@ public class EscapesRecipes extends Recipe {
             return Preconditions.check(
                     Preconditions.and(
                             new UsesType<>("com.sun.tools.javac.util.Convert", true),
-                            new UsesMethod<>("java.lang.String format(..)"),
+                            new UsesMethod<>("java.lang.String format(..)", true)
                             new UsesMethod<>("com.sun.tools.javac.util.Convert quote(..)")
                     ),
                     javaVisitor
@@ -174,7 +174,7 @@ public class EscapesRecipes extends Recipe {
 
             };
             return Preconditions.check(
-                    new UsesMethod<>("java.lang.String split(..)"),
+                    new UsesMethod<>("java.lang.String split(..)", true)
                     javaVisitor
             );
         }

--- a/src/test/resources/refaster/EscapesRecipes.java
+++ b/src/test/resources/refaster/EscapesRecipes.java
@@ -118,7 +118,7 @@ public class EscapesRecipes extends Recipe {
                     Preconditions.and(
                             new UsesType<>("com.sun.tools.javac.util.Convert", true),
                             new UsesMethod<>("java.lang.String format(..)", true)
-                            new UsesMethod<>("com.sun.tools.javac.util.Convert quote(..)")
+                            new UsesMethod<>("com.sun.tools.javac.util.Convert quote(..)", true)
                     ),
                     javaVisitor
             );

--- a/src/test/resources/refaster/FindListAddRecipe.java
+++ b/src/test/resources/refaster/FindListAddRecipe.java
@@ -79,7 +79,7 @@ public class FindListAddRecipe extends Recipe {
         return Preconditions.check(
                 Preconditions.and(
                         new UsesType<>("java.util.List", true),
-                        new UsesMethod<>("java.util.List add(..)")
+                        new UsesMethod<>("java.util.List add(..)", true)
                 ),
                 javaVisitor
         );

--- a/src/test/resources/refaster/GenericsRecipes.java
+++ b/src/test/resources/refaster/GenericsRecipes.java
@@ -113,7 +113,7 @@ public class GenericsRecipes extends Recipe {
             return Preconditions.check(
                     Preconditions.and(
                             new UsesType<>("java.util.List", true),
-                            new UsesMethod<>("java.util.Iterator next(..)", true)
+                            new UsesMethod<>("java.util.Iterator next(..)", true),
                             new UsesMethod<>("java.util.List iterator(..)", true)
                     ),
                     javaVisitor

--- a/src/test/resources/refaster/GenericsRecipes.java
+++ b/src/test/resources/refaster/GenericsRecipes.java
@@ -114,7 +114,7 @@ public class GenericsRecipes extends Recipe {
                     Preconditions.and(
                             new UsesType<>("java.util.List", true),
                             new UsesMethod<>("java.util.Iterator next(..)", true)
-                            new UsesMethod<>("java.util.List iterator(..)")
+                            new UsesMethod<>("java.util.List iterator(..)", true)
                     ),
                     javaVisitor
             );

--- a/src/test/resources/refaster/GenericsRecipes.java
+++ b/src/test/resources/refaster/GenericsRecipes.java
@@ -113,7 +113,7 @@ public class GenericsRecipes extends Recipe {
             return Preconditions.check(
                     Preconditions.and(
                             new UsesType<>("java.util.List", true),
-                            new UsesMethod<>("java.util.Iterator next(..)"),
+                            new UsesMethod<>("java.util.Iterator next(..)", true)
                             new UsesMethod<>("java.util.List iterator(..)")
                     ),
                     javaVisitor

--- a/src/test/resources/refaster/MatchingRecipes.java
+++ b/src/test/resources/refaster/MatchingRecipes.java
@@ -139,7 +139,7 @@ public class MatchingRecipes extends Recipe {
             };
             return Preconditions.check(
                     Preconditions.and(
-                            new UsesMethod<>("java.lang.String isEmpty(..)", true)
+                            new UsesMethod<>("java.lang.String isEmpty(..)", true),
                             new UsesMethod<>("java.lang.String substring(..)", true)
                     ),
                     javaVisitor

--- a/src/test/resources/refaster/MatchingRecipes.java
+++ b/src/test/resources/refaster/MatchingRecipes.java
@@ -140,7 +140,7 @@ public class MatchingRecipes extends Recipe {
             return Preconditions.check(
                     Preconditions.and(
                             new UsesMethod<>("java.lang.String isEmpty(..)", true)
-                            new UsesMethod<>("java.lang.String substring(..)")
+                            new UsesMethod<>("java.lang.String substring(..)", true)
                     ),
                     javaVisitor
             );

--- a/src/test/resources/refaster/MatchingRecipes.java
+++ b/src/test/resources/refaster/MatchingRecipes.java
@@ -139,7 +139,7 @@ public class MatchingRecipes extends Recipe {
             };
             return Preconditions.check(
                     Preconditions.and(
-                            new UsesMethod<>("java.lang.String isEmpty(..)"),
+                            new UsesMethod<>("java.lang.String isEmpty(..)", true)
                             new UsesMethod<>("java.lang.String substring(..)")
                     ),
                     javaVisitor

--- a/src/test/resources/refaster/MethodThrowsRecipe.java
+++ b/src/test/resources/refaster/MethodThrowsRecipe.java
@@ -88,7 +88,7 @@ public class MethodThrowsRecipe extends Recipe {
                         new UsesType<>("java.nio.file.Files", true),
                         new UsesType<>("java.nio.charset.StandardCharsets", true),
                         new UsesType<>("java.nio.file.Path", true),
-                        new UsesMethod<>("java.nio.file.Files readAllLines(..)")
+                        new UsesMethod<>("java.nio.file.Files readAllLines(..)", true)
                 ),
                 javaVisitor
         );

--- a/src/test/resources/refaster/MultipleDereferencesRecipes.java
+++ b/src/test/resources/refaster/MultipleDereferencesRecipes.java
@@ -116,7 +116,7 @@ public class MultipleDereferencesRecipes extends Recipe {
                     Preconditions.and(
                             new UsesType<>("java.nio.file.Files", true),
                             new UsesType<>("java.nio.file.Path", true),
-                            new UsesMethod<>("java.nio.file.Files delete(..)")
+                            new UsesMethod<>("java.nio.file.Files delete(..)", true)
                     ),
                     javaVisitor
             );

--- a/src/test/resources/refaster/MultipleDereferencesRecipes.java
+++ b/src/test/resources/refaster/MultipleDereferencesRecipes.java
@@ -172,7 +172,7 @@ public class MultipleDereferencesRecipes extends Recipe {
 
             };
             return Preconditions.check(
-                    new UsesMethod<>("java.lang.String isEmpty(..)"),
+                    new UsesMethod<>("java.lang.String isEmpty(..)", true)
                     javaVisitor
             );
         }

--- a/src/test/resources/refaster/MultipleDereferencesRecipes.java
+++ b/src/test/resources/refaster/MultipleDereferencesRecipes.java
@@ -172,7 +172,7 @@ public class MultipleDereferencesRecipes extends Recipe {
 
             };
             return Preconditions.check(
-                    new UsesMethod<>("java.lang.String isEmpty(..)", true)
+                    new UsesMethod<>("java.lang.String isEmpty(..)", true),
                     javaVisitor
             );
         }

--- a/src/test/resources/refaster/NestedPreconditionsRecipe.java
+++ b/src/test/resources/refaster/NestedPreconditionsRecipe.java
@@ -101,11 +101,11 @@ public class NestedPreconditionsRecipe extends Recipe {
                         Preconditions.or(
                                 Preconditions.and(
                                         new UsesType<>("java.util.HashMap", true),
-                                        new UsesMethod<>("java.util.HashMap <constructor>(..)")
+                                        new UsesMethod<>("java.util.HashMap <constructor>(..)", true)
                                 ),
                                 Preconditions.and(
                                         new UsesType<>("java.util.LinkedHashMap", true),
-                                        new UsesMethod<>("java.util.LinkedHashMap <constructor>(..)")
+                                        new UsesMethod<>("java.util.LinkedHashMap <constructor>(..)", true)
                                 )
                         )
                 ),

--- a/src/test/resources/refaster/PicnicRulesRecipes.java
+++ b/src/test/resources/refaster/PicnicRulesRecipes.java
@@ -111,7 +111,7 @@ public class PicnicRulesRecipes extends Recipe {
 
             };
             return Preconditions.check(
-                    new UsesMethod<>("java.lang.String replaceAll(..)"),
+                    new UsesMethod<>("java.lang.String replaceAll(..)", true)
                     javaVisitor
             );
         }

--- a/src/test/resources/refaster/PicnicRulesRecipes.java
+++ b/src/test/resources/refaster/PicnicRulesRecipes.java
@@ -111,7 +111,7 @@ public class PicnicRulesRecipes extends Recipe {
 
             };
             return Preconditions.check(
-                    new UsesMethod<>("java.lang.String replaceAll(..)", true)
+                    new UsesMethod<>("java.lang.String replaceAll(..)", true),
                     javaVisitor
             );
         }

--- a/src/test/resources/refaster/RefasterAnyOfRecipes.java
+++ b/src/test/resources/refaster/RefasterAnyOfRecipes.java
@@ -197,11 +197,11 @@ public class RefasterAnyOfRecipes extends Recipe {
                             Preconditions.or(
                                     Preconditions.and(
                                             new UsesType<>("java.util.LinkedList", true),
-                                            new UsesMethod<>("java.util.LinkedList <constructor>(..)")
+                                            new UsesMethod<>("java.util.LinkedList <constructor>(..)", true)
                                     ),
                                     Preconditions.and(
                                             new UsesType<>("java.util.Collections", true),
-                                            new UsesMethod<>("java.util.Collections emptyList(..)")
+                                            new UsesMethod<>("java.util.Collections emptyList(..)", true)
                                     )
                             )
                     ),
@@ -272,7 +272,7 @@ public class RefasterAnyOfRecipes extends Recipe {
             return Preconditions.check(
                     Preconditions.or(
                             new UsesMethod<>("java.lang.String valueOf(..)", true)
-                            new UsesMethod<>("java.lang.String copyValueOf(..)")
+                            new UsesMethod<>("java.lang.String copyValueOf(..)", true)
                     ),
                     javaVisitor
             );

--- a/src/test/resources/refaster/RefasterAnyOfRecipes.java
+++ b/src/test/resources/refaster/RefasterAnyOfRecipes.java
@@ -124,7 +124,7 @@ public class RefasterAnyOfRecipes extends Recipe {
 
             };
             return Preconditions.check(
-                    new UsesMethod<>("java.lang.String length(..)"),
+                    new UsesMethod<>("java.lang.String length(..)", true)
                     javaVisitor
             );
         }
@@ -271,7 +271,7 @@ public class RefasterAnyOfRecipes extends Recipe {
             };
             return Preconditions.check(
                     Preconditions.or(
-                            new UsesMethod<>("java.lang.String valueOf(..)"),
+                            new UsesMethod<>("java.lang.String valueOf(..)", true)
                             new UsesMethod<>("java.lang.String copyValueOf(..)")
                     ),
                     javaVisitor

--- a/src/test/resources/refaster/RefasterAnyOfRecipes.java
+++ b/src/test/resources/refaster/RefasterAnyOfRecipes.java
@@ -124,7 +124,7 @@ public class RefasterAnyOfRecipes extends Recipe {
 
             };
             return Preconditions.check(
-                    new UsesMethod<>("java.lang.String length(..)", true)
+                    new UsesMethod<>("java.lang.String length(..)", true),
                     javaVisitor
             );
         }
@@ -271,7 +271,7 @@ public class RefasterAnyOfRecipes extends Recipe {
             };
             return Preconditions.check(
                     Preconditions.or(
-                            new UsesMethod<>("java.lang.String valueOf(..)", true)
+                            new UsesMethod<>("java.lang.String valueOf(..)", true),
                             new UsesMethod<>("java.lang.String copyValueOf(..)", true)
                     ),
                     javaVisitor

--- a/src/test/resources/refaster/ShouldAddImportsRecipes.java
+++ b/src/test/resources/refaster/ShouldAddImportsRecipes.java
@@ -116,7 +116,7 @@ public class ShouldAddImportsRecipes extends Recipe {
 
             };
             return Preconditions.check(
-                    new UsesMethod<>("java.lang.String valueOf(..)", true)
+                    new UsesMethod<>("java.lang.String valueOf(..)", true),
                     javaVisitor
             );
         }
@@ -245,7 +245,7 @@ public class ShouldAddImportsRecipes extends Recipe {
 
             };
             return Preconditions.check(
-                    new UsesMethod<>("java.util.Objects hash(..)", true)
+                    new UsesMethod<>("java.util.Objects hash(..)", true),
                     javaVisitor
             );
         }
@@ -302,7 +302,7 @@ public class ShouldAddImportsRecipes extends Recipe {
             return Preconditions.check(
                     Preconditions.and(
                             new UsesType<>("java.nio.file.Path", true),
-                            new UsesMethod<>("java.io.File exists(..)", true)
+                            new UsesMethod<>("java.io.File exists(..)", true),
                             new UsesMethod<>("java.nio.file.Path toFile(..)", true)
                     ),
                     javaVisitor
@@ -351,7 +351,7 @@ public class ShouldAddImportsRecipes extends Recipe {
 
             };
             return Preconditions.check(
-                    new UsesMethod<>("java.lang.String isEmpty(..)", true)
+                    new UsesMethod<>("java.lang.String isEmpty(..)", true),
                     javaVisitor
             );
         }

--- a/src/test/resources/refaster/ShouldAddImportsRecipes.java
+++ b/src/test/resources/refaster/ShouldAddImportsRecipes.java
@@ -186,9 +186,9 @@ public class ShouldAddImportsRecipes extends Recipe {
                     Preconditions.or(
                             Preconditions.and(
                                     new UsesType<>("java.util.Objects", true),
-                                    new UsesMethod<>("java.util.Objects equals(..)")
+                                    new UsesMethod<>("java.util.Objects equals(..)", true)
                             ),
-                            new UsesMethod<>("java.lang.Integer compare(..)")
+                            new UsesMethod<>("java.lang.Integer compare(..)", true)
                     ),
                     javaVisitor
             );
@@ -303,7 +303,7 @@ public class ShouldAddImportsRecipes extends Recipe {
                     Preconditions.and(
                             new UsesType<>("java.nio.file.Path", true),
                             new UsesMethod<>("java.io.File exists(..)", true)
-                            new UsesMethod<>("java.nio.file.Path toFile(..)")
+                            new UsesMethod<>("java.nio.file.Path toFile(..)", true)
                     ),
                     javaVisitor
             );

--- a/src/test/resources/refaster/ShouldAddImportsRecipes.java
+++ b/src/test/resources/refaster/ShouldAddImportsRecipes.java
@@ -116,7 +116,7 @@ public class ShouldAddImportsRecipes extends Recipe {
 
             };
             return Preconditions.check(
-                    new UsesMethod<>("java.lang.String valueOf(..)"),
+                    new UsesMethod<>("java.lang.String valueOf(..)", true)
                     javaVisitor
             );
         }
@@ -245,7 +245,7 @@ public class ShouldAddImportsRecipes extends Recipe {
 
             };
             return Preconditions.check(
-                    new UsesMethod<>("java.util.Objects hash(..)"),
+                    new UsesMethod<>("java.util.Objects hash(..)", true)
                     javaVisitor
             );
         }
@@ -302,7 +302,7 @@ public class ShouldAddImportsRecipes extends Recipe {
             return Preconditions.check(
                     Preconditions.and(
                             new UsesType<>("java.nio.file.Path", true),
-                            new UsesMethod<>("java.io.File exists(..)"),
+                            new UsesMethod<>("java.io.File exists(..)", true)
                             new UsesMethod<>("java.nio.file.Path toFile(..)")
                     ),
                     javaVisitor
@@ -351,7 +351,7 @@ public class ShouldAddImportsRecipes extends Recipe {
 
             };
             return Preconditions.check(
-                    new UsesMethod<>("java.lang.String isEmpty(..)"),
+                    new UsesMethod<>("java.lang.String isEmpty(..)", true)
                     javaVisitor
             );
         }

--- a/src/test/resources/refaster/ShouldSupportNestedClassesRecipes.java
+++ b/src/test/resources/refaster/ShouldSupportNestedClassesRecipes.java
@@ -113,7 +113,7 @@ public class ShouldSupportNestedClassesRecipes extends Recipe {
 
             };
             return Preconditions.check(
-                    new UsesMethod<>("java.lang.String length(..)", true)
+                    new UsesMethod<>("java.lang.String length(..)", true),
                     javaVisitor
             );
         }
@@ -168,7 +168,7 @@ public class ShouldSupportNestedClassesRecipes extends Recipe {
 
             };
             return Preconditions.check(
-                    new UsesMethod<>("java.lang.String length(..)", true)
+                    new UsesMethod<>("java.lang.String length(..)", true),
                     javaVisitor
             );
         }

--- a/src/test/resources/refaster/ShouldSupportNestedClassesRecipes.java
+++ b/src/test/resources/refaster/ShouldSupportNestedClassesRecipes.java
@@ -113,7 +113,7 @@ public class ShouldSupportNestedClassesRecipes extends Recipe {
 
             };
             return Preconditions.check(
-                    new UsesMethod<>("java.lang.String length(..)"),
+                    new UsesMethod<>("java.lang.String length(..)", true)
                     javaVisitor
             );
         }
@@ -168,7 +168,7 @@ public class ShouldSupportNestedClassesRecipes extends Recipe {
 
             };
             return Preconditions.check(
-                    new UsesMethod<>("java.lang.String length(..)"),
+                    new UsesMethod<>("java.lang.String length(..)", true)
                     javaVisitor
             );
         }

--- a/src/test/resources/refaster/SimplifyBooleansRecipe.java
+++ b/src/test/resources/refaster/SimplifyBooleansRecipe.java
@@ -84,7 +84,7 @@ public class SimplifyBooleansRecipe extends Recipe {
 
         };
         return Preconditions.check(
-                new UsesMethod<>("java.lang.String replaceAll(..)", true)
+                new UsesMethod<>("java.lang.String replaceAll(..)", true),
                 javaVisitor
         );
     }

--- a/src/test/resources/refaster/SimplifyBooleansRecipe.java
+++ b/src/test/resources/refaster/SimplifyBooleansRecipe.java
@@ -84,7 +84,7 @@ public class SimplifyBooleansRecipe extends Recipe {
 
         };
         return Preconditions.check(
-                new UsesMethod<>("java.lang.String replaceAll(..)"),
+                new UsesMethod<>("java.lang.String replaceAll(..)", true)
                 javaVisitor
         );
     }

--- a/src/test/resources/refaster/UseStringIsEmptyRecipe.java
+++ b/src/test/resources/refaster/UseStringIsEmptyRecipe.java
@@ -84,7 +84,7 @@ public class UseStringIsEmptyRecipe extends Recipe {
 
         };
         return Preconditions.check(
-                new UsesMethod<>("java.lang.String length(..)", true)
+                new UsesMethod<>("java.lang.String length(..)", true),
                 javaVisitor
         );
     }

--- a/src/test/resources/refaster/UseStringIsEmptyRecipe.java
+++ b/src/test/resources/refaster/UseStringIsEmptyRecipe.java
@@ -84,7 +84,7 @@ public class UseStringIsEmptyRecipe extends Recipe {
 
         };
         return Preconditions.check(
-                new UsesMethod<>("java.lang.String length(..)"),
+                new UsesMethod<>("java.lang.String length(..)", true)
                 javaVisitor
         );
     }


### PR DESCRIPTION
## What's changed?
Instead of `new UsesMethod<>("java.lang.String join(..)")`
Generate `new UsesMethod<>("java.lang.String join(..)", true)`

## What's your motivation?
We want to also match methods overrridden in sub classes where possible.

## Anything in particular you'd like reviewers to focus on?
Not sure if this might negatively affect some existing recipes that have come to expect stricter matching.
Figured open this PR to get the discussion around that going.

Also not yet sure if the `before.matcher(getCursor())).find()` would even match.

## Anyone you would like to review specifically?
@knutwannheden 

## Have you considered any alternatives or workarounds?
We could add explicit recipes for overridden methods, but that quickly explodes the number of recipes.

We could also offer a way to tag before templates where overridden methods should also be matched.

## Any additional context
Came up while discussing recipes for Apache POI, where `Cell` might have multiple extending classes.