### PR TITLE
Switch to com.netflix.nebula plugins after failed `:verifyPublication`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     `java-library`
     signing
 
-    id("nebula.maven-resolved-dependencies") version "17.3.2"
+    id("com.netflix.nebula.maven-resolved-dependencies") version "21.0.0"
     id("com.netflix.nebula.release") version "19.0.10"
     id("io.github.gradle-nexus.publish-plugin") version "1.0.0"
 
@@ -17,19 +17,19 @@ plugins {
     id("com.github.jk1.dependency-license-report") version "1.16"
     id("org.owasp.dependencycheck") version "latest.release"
 
-    id("nebula.maven-publish") version "17.3.2"
-    id("nebula.contacts") version "5.1.0"
-    id("nebula.info") version "11.1.0"
+    id("com.netflix.nebula.maven-publish") version "21.0.0"
+    id("com.netflix.nebula.contacts") version "7.0.1"
+    id("com.netflix.nebula.info") version "13.1.2"
 
-    id("nebula.javadoc-jar") version "17.3.2"
-    id("nebula.source-jar") version "17.3.2"
-    id("nebula.maven-apache-license") version "17.3.2"
+    id("com.netflix.nebula.javadoc-jar") version "21.0.0"
+    id("com.netflix.nebula.source-jar") version "21.0.0"
+    id("com.netflix.nebula.maven-apache-license") version "21.0.0"
 }
 
 group = "org.openrewrite"
 description = "Auto-templating for rewrite-java."
 
-apply(plugin = "nebula.publish-verification")
+apply(plugin = "com.netflix.nebula.publish-verification")
 
 configure<ReleasePluginExtension> {
     defaultVersionStrategy = SNAPSHOT(project)


### PR DESCRIPTION
## What's your motivation?
https://github.com/openrewrite/rewrite-templating/actions/runs/10418640947/job/28855160137

```
* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':verifyPublication'.
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.lambda$executeIfValid$1(ExecuteActionsTaskExecuter.java:130)
	at org.gradle.internal.Try$Failure.ifSuccessfulOrElse(Try.java:293)
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeIfValid(ExecuteActionsTaskExecuter.java:128)
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:116)
	at org.gradle.api.internal.tasks.execution.FinalizePropertiesTaskExecuter.execute(FinalizePropertiesTaskExecuter.java:46)
	at org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter.execute(ResolveTaskExecutionModeExecuter.java:51)
	at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:57)
	at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:74)
	at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:36)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.executeTask(EventFiringTaskExecuter.java:77)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:55)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:52)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:209)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:166)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter.execute(EventFiringTaskExecuter.java:52)
	at org.gradle.execution.plan.LocalTaskNodeExecutor.execute(LocalTaskNodeExecutor.java:42)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:331)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:318)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.lambda$execute$0(DefaultTaskExecutionGraph.java:314)
	at org.gradle.internal.operations.CurrentBuildOperationRef.with(CurrentBuildOperationRef.java:85)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:314)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:303)
	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.execute(DefaultPlanExecutor.java:459)
	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.run(DefaultPlanExecutor.java:376)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:48)
Caused by: java.lang.NoSuchMethodError: 'org.gradle.api.artifacts.result.ResolvedVariantResult org.gradle.api.artifacts.result.ResolvedComponentResult.getVariant()'
	at nebula.plugin.publishing.verification.StatusVerification.hasStatusScheme(StatusVerification.groovy:51)
	at nebula.plugin.publishing.verification.StatusVerification.access$2(StatusVerification.groovy)
	at nebula.plugin.publishing.verification.StatusVerification$_verify_closure3.doCall$original(StatusVerification.groovy:30)
	at nebula.plugin.publishing.verification.StatusVerification$_verify_closure3.doCall(StatusVerification.groovy)
	at nebula.plugin.publishing.verification.StatusVerification$_verify_closure3.call(StatusVerification.groovy)
	at nebula.plugin.publishing.verification.StatusVerification.verify(StatusVerification.groovy:27)
	at nebula.plugin.publishing.verification.VerifyPublicationTask.verifyDependencies(VerifyPublicationTask.groovy:28)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
```