### PR TITLE
Inline return of new JavaVisitor

### DIFF
--- a/src/test/resources/refaster/CharacterEscapeAnnotationRecipe.java
+++ b/src/test/resources/refaster/CharacterEscapeAnnotationRecipe.java
@@ -65,7 +65,7 @@ public class CharacterEscapeAnnotationRecipe extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
+        return new AbstractRefasterJavaVisitor() {
             final JavaTemplate before = JavaTemplate
                     .builder("\"The answer to life, the universe, and everything\"")
                     .build();
@@ -88,6 +88,5 @@ public class CharacterEscapeAnnotationRecipe extends Recipe {
             }
 
         };
-        return javaVisitor;
     }
 }

--- a/src/test/resources/refaster/MultipleDereferencesRecipes.java
+++ b/src/test/resources/refaster/MultipleDereferencesRecipes.java
@@ -203,7 +203,7 @@ public class MultipleDereferencesRecipes extends Recipe {
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
-            JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
+            return new AbstractRefasterJavaVisitor() {
                 final JavaTemplate before = JavaTemplate
                         .builder("#{o:any(java.lang.Object)} == #{o}")
                         .build();
@@ -226,7 +226,6 @@ public class MultipleDereferencesRecipes extends Recipe {
                 }
 
             };
-            return javaVisitor;
         }
     }
 

--- a/src/test/resources/refaster/ParametersRecipes.java
+++ b/src/test/resources/refaster/ParametersRecipes.java
@@ -88,7 +88,7 @@ public class ParametersRecipes extends Recipe {
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
-            JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
+            return new AbstractRefasterJavaVisitor() {
                 final JavaTemplate before = JavaTemplate
                         .builder("#{s:any(java.lang.String)} == #{s}")
                         .build();
@@ -111,7 +111,6 @@ public class ParametersRecipes extends Recipe {
                 }
 
             };
-            return javaVisitor;
         }
     }
 
@@ -140,7 +139,7 @@ public class ParametersRecipes extends Recipe {
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
-            JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
+            return new AbstractRefasterJavaVisitor() {
                 final JavaTemplate before1 = JavaTemplate
                         .builder("#{a:any(int)} == #{b:any(int)}")
                         .build();
@@ -174,7 +173,6 @@ public class ParametersRecipes extends Recipe {
                 }
 
             };
-            return javaVisitor;
         }
     }
 

--- a/src/test/resources/refaster/SimplifyTernaryRecipes.java
+++ b/src/test/resources/refaster/SimplifyTernaryRecipes.java
@@ -88,7 +88,7 @@ public class SimplifyTernaryRecipes extends Recipe {
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
-            JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
+            return new AbstractRefasterJavaVisitor() {
                 final JavaTemplate before = JavaTemplate
                         .builder("#{expr:any(boolean)} ? true : false")
                         .build();
@@ -111,7 +111,6 @@ public class SimplifyTernaryRecipes extends Recipe {
                 }
 
             };
-            return javaVisitor;
         }
     }
 
@@ -140,7 +139,7 @@ public class SimplifyTernaryRecipes extends Recipe {
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
-            JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
+            return new AbstractRefasterJavaVisitor() {
                 final JavaTemplate before = JavaTemplate
                         .builder("#{expr:any(boolean)} ? false : true")
                         .build();
@@ -163,7 +162,6 @@ public class SimplifyTernaryRecipes extends Recipe {
                 }
 
             };
-            return javaVisitor;
         }
     }
 

--- a/src/test/resources/refaster/UnnamedPackageRecipe.java
+++ b/src/test/resources/refaster/UnnamedPackageRecipe.java
@@ -58,7 +58,7 @@ public class UnnamedPackageRecipe extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
+        return new AbstractRefasterJavaVisitor() {
             final JavaTemplate before = JavaTemplate
                     .builder("\"This class is located in the default package\"")
                     .build();
@@ -81,6 +81,5 @@ public class UnnamedPackageRecipe extends Recipe {
             }
 
         };
-        return javaVisitor;
     }
 }


### PR DESCRIPTION
## What's changed?
Extract `newAbstractRefasterJavaVisitor` method, and use it's return value directly when there are no preconditions.

## What's your motivation?
Reduces the number of suggested changes when running
https://docs.openrewrite.org/recipes/recipes/openrewritebestpractices