### PR TITLE
Add option to override Generated annotation with Jakarta

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,7 @@ dependencies {
     // Skip `2.1.0-alpha0` for now over "class file has wrong version 55.0, should be 52.0"
     testImplementation("org.slf4j:slf4j-api:2.0.+")
     testImplementation("com.google.testing.compile:compile-testing:latest.release")
+    testImplementation("jakarta.annotation:jakarta.annotation-api:2.+")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:latest.release")
     testImplementation("org.junit.jupiter:junit-jupiter-params:latest.release")


### PR DESCRIPTION
## What's changed?
Add a `-Arewrite.generatedAnnotation` option that folks can use to switch to `jakarta.annotation.Generated`.

## What's your motivation?
Allow usage on from newer Java version that lack the default `javax.annotation.Generated` used for Java 8 compatibility.

## Have you considered any alternatives or workarounds?
Could have made the Generated annotation at all optional, but figured we can handle that separately if it comes up.

## Any additional context
Came up as a request.