### PR TITLE
Fix indenting

### DIFF
--- a/src/main/java/org/openrewrite/java/template/internal/StringUtils.java
+++ b/src/main/java/org/openrewrite/java/template/internal/StringUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.template.internal;
 
 public class StringUtils {

--- a/src/main/java/org/openrewrite/java/template/internal/StringUtils.java
+++ b/src/main/java/org/openrewrite/java/template/internal/StringUtils.java
@@ -1,0 +1,8 @@
+package org.openrewrite.java.template.internal;
+
+public class StringUtils {
+    public static String indent(String text, int indent) {
+        String whitespace = String.format("%" + indent + "s", " ");
+        return whitespace + text.replaceAll("\\R", "\n" + whitespace);
+    }
+}

--- a/src/main/java/org/openrewrite/java/template/processor/Precondition.java
+++ b/src/main/java/org/openrewrite/java/template/processor/Precondition.java
@@ -16,7 +16,6 @@
 package org.openrewrite.java.template.processor;
 
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 import lombok.Value;
 
 import java.util.*;
@@ -60,7 +59,6 @@ public abstract class Precondition {
 
     @Value
     @AllArgsConstructor
-    @EqualsAndHashCode(callSuper = false, of = "preconditions")
     public static class Or extends Precondition {
         Set<Precondition> preconditions;
 
@@ -163,7 +161,6 @@ public abstract class Precondition {
 
     @Value
     @AllArgsConstructor
-    @EqualsAndHashCode(callSuper = false, of = "preconditions")
     public static class And extends Precondition {
         Set<Precondition> preconditions;
 

--- a/src/main/java/org/openrewrite/java/template/processor/Precondition.java
+++ b/src/main/java/org/openrewrite/java/template/processor/Precondition.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.template.processor;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Value;
 
 import java.util.*;

--- a/src/main/java/org/openrewrite/java/template/processor/Precondition.java
+++ b/src/main/java/org/openrewrite/java/template/processor/Precondition.java
@@ -60,6 +60,7 @@ public abstract class Precondition {
 
     @Value
     @AllArgsConstructor
+    @EqualsAndHashCode(callSuper = false)
     public static class Or extends Precondition {
         Set<Precondition> preconditions;
 
@@ -162,6 +163,7 @@ public abstract class Precondition {
 
     @Value
     @AllArgsConstructor
+    @EqualsAndHashCode(callSuper = false)
     public static class And extends Precondition {
         Set<Precondition> preconditions;
 

--- a/src/main/java/org/openrewrite/java/template/processor/Precondition.java
+++ b/src/main/java/org/openrewrite/java/template/processor/Precondition.java
@@ -15,12 +15,14 @@
  */
 package org.openrewrite.java.template.processor;
 
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 
 import java.util.*;
 
-import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.joining;
+import static org.openrewrite.java.template.internal.StringUtils.indent;
 
 public abstract class Precondition {
     private static final Comparator<String> BY_USES_TYPE_FIRST = Comparator
@@ -57,10 +59,14 @@ public abstract class Precondition {
     }
 
     @Value
+    @AllArgsConstructor
     @EqualsAndHashCode(callSuper = false, of = "preconditions")
     public static class Or extends Precondition {
         Set<Precondition> preconditions;
-        int indent;
+
+        public Or(Precondition... preconditions) {
+            this.preconditions = new HashSet<>(Arrays.asList(preconditions));
+        }
 
         @Override
         boolean fitsInto(Precondition p) {
@@ -142,8 +148,8 @@ public abstract class Precondition {
 
             if (!commons.isEmpty()) {
                 preconditions.forEach(it -> ((And) it).preconditions.removeAll(commons));
-                commons.add(new Or(preconditions, indent));
-                return new And(commons, indent);
+                commons.add(new Or(preconditions));
+                return new And(commons);
             }
 
             return this;
@@ -151,15 +157,19 @@ public abstract class Precondition {
 
         @Override
         public String toString() {
-            return joinPreconditions(preconditions, "or", indent);
+            return joinPreconditions(preconditions, "or");
         }
     }
 
     @Value
+    @AllArgsConstructor
     @EqualsAndHashCode(callSuper = false, of = "preconditions")
     public static class And extends Precondition {
         Set<Precondition> preconditions;
-        int indent;
+
+        public And(Precondition... preconditions) {
+            this.preconditions = new HashSet<>(Arrays.asList(preconditions));
+        }
 
         @Override
         boolean fitsInto(Precondition p) {
@@ -174,20 +184,19 @@ public abstract class Precondition {
 
         @Override
         public String toString() {
-            return joinPreconditions(preconditions, "and", indent);
+            return joinPreconditions(preconditions, "and");
         }
     }
 
-    private static String joinPreconditions(Collection<Precondition> rules, String op, int indent) {
+    private static String joinPreconditions(Collection<Precondition> rules, String op) {
         if (rules.isEmpty()) {
             return "";
         } else if (rules.size() == 1) {
             return rules.iterator().next().toString();
         }
-        String whitespace = String.format("%" + indent + "s", " ");
-        Set<String> preconditions = rules.stream().map(Object::toString).sorted(BY_USES_TYPE_FIRST).collect(toCollection(LinkedHashSet::new));
+        String preconditions = rules.stream().map(Object::toString).sorted(BY_USES_TYPE_FIRST).collect(joining(",\n"));
         return "Preconditions." + op + "(\n" +
-                whitespace + String.join(",\n" + whitespace, preconditions) + "\n" +
-                whitespace.substring(0, indent - 4) + ')';
+                indent(preconditions, 4) + "\n" +
+                ")";
     }
 }

--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -623,8 +623,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                     return null;
                 }
 
-                return
-                        new Precondition.Or(
+                return new Precondition.Or(
                                 preconditions.values().stream()
                                         .map(Precondition.And::new)
                                         .collect(toSet())

--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -51,6 +51,7 @@ import java.util.stream.Stream;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.*;
+import static org.openrewrite.java.template.internal.StringUtils.indent;
 import static org.openrewrite.java.template.processor.RefasterTemplateProcessor.AFTER_TEMPLATE;
 import static org.openrewrite.java.template.processor.RefasterTemplateProcessor.BEFORE_TEMPLATE;
 
@@ -232,7 +233,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                     } else {
                         recipe.append(String.format("        JavaVisitor<ExecutionContext> javaVisitor = %s;\n", javaVisitor));
                         recipe.append("        return Preconditions.check(\n");
-                        recipe.append("                ").append(preconditions).append(",\n");
+                        recipe.append(indent(preconditions.toString(), 16)).append(",\n");
                         recipe.append("                javaVisitor\n");
                         recipe.append("        );\n");
                     }
@@ -622,12 +623,12 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                     return null;
                 }
 
-                return new Precondition.Or(
-                        preconditions.values().stream()
-                                .map(it -> new Precondition.And(it, indent + 4))
-                                .collect(toSet())
-                        , indent + 4)
-                        .prune();
+                return
+                        new Precondition.Or(
+                                preconditions.values().stream()
+                                        .map(Precondition.And::new)
+                                        .collect(toSet())
+                        ).prune();
             }
         }.scan(cu);
     }

--- a/src/test/java/org/openrewrite/java/template/processor/PreconditionTest.java
+++ b/src/test/java/org/openrewrite/java/template/processor/PreconditionTest.java
@@ -30,34 +30,29 @@ class PreconditionTest {
     @Test
     void toStringWithInden() {
         String result = new Or(
-          setOf(
-            new And(
-              setOf(
-                new Rule("A"),
-                new Rule("B"),
-                new Rule("C")),
-              4
-            ),
-            new And(
-              setOf(
-                new Rule("X"),
-                new Rule("Y"),
-                new Rule("Z")),
-              4
-            )
-          ), 4).toString();
+          new And(
+            new Or(new Rule("A"), new Rule("B")),
+            new Or(new Rule("C"), new Rule("D"))
+          ),
+          new And(new Rule("X"), new Rule("Y"), new Rule("Z"))
+        ).toString();
 
         assertThat(result).isEqualTo("Preconditions.or(\n" +
           "    Preconditions.and(\n" +
-          "    A,\n" +
-          "    B,\n" +
-          "    C\n" +
-          "),\n" +
+          "        Preconditions.or(\n" +
+          "            A,\n" +
+          "            B\n" +
+          "        ),\n" +
+          "        Preconditions.or(\n" +
+          "            C,\n" +
+          "            D\n" +
+          "        )\n" +
+          "    ),\n" +
           "    Preconditions.and(\n" +
-          "    X,\n" +
-          "    Y,\n" +
-          "    Z\n" +
-          ")\n" +
+          "        X,\n" +
+          "        Y,\n" +
+          "        Z\n" +
+          "    )\n" +
           ")");
     }
 
@@ -68,52 +63,32 @@ class PreconditionTest {
 
     @Test
     void orFitsInOr() {
-        boolean result = new Or(
-          setOf(new Rule("A"), new Rule("B")),
-          4
-        ).fitsInto(new Or(
-          setOf(new Rule("B"), new Rule("A")),
-          4
-        ));
+        boolean result = new Or(new Rule("A"), new Rule("B"))
+          .fitsInto(new Or(new Rule("B"), new Rule("A")));
 
         assertThat(result).isTrue();
     }
 
     @Test
     void ardFitsNotInAndWithDifferentRules() {
-        boolean result = new Or(
-          setOf(new Rule("A"), new Rule("C")),
-          4
-        ).fitsInto(new Or(
-          setOf(new Rule("B"), new Rule("A")),
-          4
-        ));
+        boolean result = new Or(new Rule("A"), new Rule("C"))
+          .fitsInto(new Or(new Rule("B"), new Rule("A")));
 
         assertThat(result).isFalse();
     }
 
     @Test
     void andFitsInAnd() {
-        boolean result = new And(
-          setOf(new Rule("A")),
-          4
-        ).fitsInto(new And(
-          setOf(new Rule("B"), new Rule("A")),
-          4
-        ));
+        boolean result = new And(new Rule("A"))
+          .fitsInto(new And(new Rule("B"), new Rule("A")));
 
         assertThat(result).isTrue();
     }
 
     @Test
     void andFitsNotInAndWithDifferentRules() {
-        boolean result = new And(
-          setOf(new Rule("A"), new Rule("C")),
-          4
-        ).fitsInto(new And(
-          setOf(new Rule("B"), new Rule("A")),
-          4
-        ));
+        boolean result = new And(new Rule("A"), new Rule("C"))
+          .fitsInto(new And(new Rule("B"), new Rule("A")));
 
         assertThat(result).isFalse();
     }
@@ -127,47 +102,27 @@ class PreconditionTest {
 
     @Test
     void sameRulesArePrunedAutomaticallyInAnOr() {
-        Precondition result = new Or(
-          setOf(new Rule("A"), new Rule("A")),
-          4
-        );
+        Precondition result = new Or(new Rule("A"), new Rule("A"));
 
-        assertThat(result).isEqualTo(new Or(
-          setOf(new Rule("A")),
-          4
-        ));
+        assertThat(result).isEqualTo(new Or(new Rule("A")));
     }
 
     @Test
     void pruneOrWithAnds() {
         Precondition result = new Or(
-          setOf(
-            new And(
-              setOf(new Rule("A"), new Rule("B")),
-              4
-            ),
-            new And(
-              setOf(new Rule("A"), new Rule("B"), new Rule("C")),
-              4
-            )
-          ), 4).prune();
+          new And(new Rule("A"), new Rule("B")),
+          new And(new Rule("A"), new Rule("B"), new Rule("C"))
+        ).prune();
 
-        assertThat(result).isEqualTo(new And(
-          setOf(new Rule("A"), new Rule("B")),
-          4
-        ));
+        assertThat(result).isEqualTo(new And(new Rule("A"), new Rule("B")));
     }
 
     @Test
     void pruneOrWithAndAndRule() {
         Precondition result = new Or(
-          setOf(
-            new And(
-              setOf(new Rule("A"), new Rule("B")),
-              4
-            ),
-            new Rule("B")
-          ), 4).prune();
+          new And(new Rule("A"), new Rule("B")),
+          new Rule("B")
+        ).prune();
 
         assertThat(result).isEqualTo(new Rule("B"));
     }
@@ -175,27 +130,19 @@ class PreconditionTest {
     @Test
     void pruneOrWithTypeChange() {
         Precondition result = new Or(
-          setOf(
-            new And(
-              setOf(new Rule("A"), new Rule("B"), new Rule("C")),
-              4
-            ),
-            new And(
-              setOf(new Rule("D"), new Rule("B"), new Rule("E")),
-              4
-            )
-          ), 4).prune();
+          new And(new Rule("A"), new Rule("B"), new Rule("C")),
+          new And(new Rule("D"), new Rule("B"), new Rule("E"))
+        ).prune();
 
-        assertThat(result).isEqualTo(new And(
-          setOf(
+        assertThat(result).isEqualTo(
+          new And(
             new Rule("B"),
             new Or(
-              setOf(
-                new And(setOf(new Rule("A"), new Rule("C")), 4),
-                new And(setOf(new Rule("D"), new Rule("E")), 4)
-              ), 4
+              new And(new Rule("A"), new Rule("C")),
+              new And(new Rule("D"), new Rule("E"))
             )
-          ), 4));
+          )
+        );
     }
 
     @SafeVarargs


### PR DESCRIPTION
## What's changed?
After 
- https://github.com/openrewrite/rewrite-templating/pull/120

there were missing some starting spaces in the recipes. This change put the indenting back to the whole precondition block + removes the `indent` field of the Precondition classes (the printer always prints 4 spaces, so no need to have this configurable).

## What's your motivation?
- https://github.com/PicnicSupermarket/error-prone-support/pull/1470#pullrequestreview-2515089902

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
