### PR TITLE
Bugfix: Preconditions of overloaded @BeforeTemplate methods are filtered away

### DIFF
--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -589,7 +589,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
 
             /* Generate the minimal precondition that would allow to match each before template individually. */
             private @Nullable Precondition generatePreconditions(List<TemplateDescriptor> beforeTemplates, int indent) {
-                Map<String, Set<Precondition>> preconditions = new LinkedHashMap<>();
+                Set<Set<Precondition>> preconditions = new HashSet<>();
                 for (TemplateDescriptor beforeTemplate : beforeTemplates) {
                     int arity = beforeTemplate.getArity();
                     for (int i = 0; i < arity; i++) {
@@ -612,7 +612,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                         }
 
                         if (!usesVisitors.isEmpty()) {
-                            preconditions.put(beforeTemplate.method.name.toString() + (arity == 1 ? "" : "$" + i), usesVisitors);
+                            preconditions.add(usesVisitors);
                         } else {
                             return null; // At least one of the before templates has no preconditions, so we can not use any preconditions
                         }
@@ -624,7 +624,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                 }
 
                 return new Precondition.Or(
-                                preconditions.values().stream()
+                                preconditions.stream()
                                         .map(Precondition.And::new)
                                         .collect(toSet())
                         ).prune();

--- a/src/test/resources/refaster/PreconditionsVerifier.java
+++ b/src/test/resources/refaster/PreconditionsVerifier.java
@@ -28,12 +28,12 @@ import java.util.Map;
 public class PreconditionsVerifier {
     public static class NoUsesTypeWhenBeforeTemplateContainsPrimitiveOrString {
         @BeforeTemplate
-        void doubleAndInt(double actual, int ignore) {
+        void before(double actual, int ignore) {
             System.out.println(actual);
         }
 
         @BeforeTemplate
-        void stringAndString(String actual, String ignore) {
+        void before(String actual, String ignore) {
             System.out.println(actual);
         }
 
@@ -45,12 +45,12 @@ public class PreconditionsVerifier {
 
     public static class UsesTypeWhenBeforeTemplateContainsPrimitiveOrStringAndTypeInSomeBeforeBody {
         @BeforeTemplate
-        String string(String value) {
+        String before(String value) {
             return Convert.quote(value);
         }
 
         @BeforeTemplate
-        String _int(int value) {
+        String before(int value) {
             return String.valueOf(value);
         }
 
@@ -62,12 +62,12 @@ public class PreconditionsVerifier {
 
     public static class UsesTypeWhenBeforeTemplateContainsPrimitiveOrStringAndTypeInAllBeforeBody {
         @BeforeTemplate
-        String string(String value) {
+        String before(String value) {
             return Convert.quote(value);
         }
 
         @BeforeTemplate
-        String _int(int value) {
+        String before(int value) {
             return Convert.quote(String.valueOf(value));
         }
 
@@ -79,12 +79,12 @@ public class PreconditionsVerifier {
 
     public static class NoUsesTypeWhenBeforeTemplateContainsPrimitiveAndAnotherType {
         @BeforeTemplate
-        void _int(int actual) {
+        void before(int actual) {
             System.out.println(actual);
         }
 
         @BeforeTemplate
-        void map(Map<?, ?> actual) {
+        void before(Map<?, ?> actual) {
             System.out.println(actual);
         }
 
@@ -96,12 +96,12 @@ public class PreconditionsVerifier {
 
     public static class NoUsesTypeWhenBeforeTemplateContainsStringAndAnotherType {
         @BeforeTemplate
-        void string(String actual) {
+        void before(String actual) {
             System.out.println(actual);
         }
 
         @BeforeTemplate
-        void map(Map<?, ?> actual) {
+        void before(Map<?, ?> actual) {
             System.out.println(actual);
         }
 
@@ -130,12 +130,12 @@ public class PreconditionsVerifier {
 
     public static class UsesTypeMapOrListWhenBeforeTemplateContainsMapAndList {
         @BeforeTemplate
-        void list(List<?> actual) {
+        void before(List<?> actual) {
             System.out.println(actual);
         }
 
         @BeforeTemplate
-        void map(Map<?, ?> actual) {
+        void before(Map<?, ?> actual) {
             System.out.println(actual);
         }
 

--- a/src/test/resources/refaster/PreconditionsVerifierRecipes.java
+++ b/src/test/resources/refaster/PreconditionsVerifierRecipes.java
@@ -88,16 +88,16 @@ public class PreconditionsVerifierRecipes extends Recipe {
 
         @Override
         public String getDescription() {
-            return "Recipe created for the following Refaster template:\n```java\npublic static class NoUsesTypeWhenBeforeTemplateContainsPrimitiveOrString {\n    \n    @BeforeTemplate()\n    void doubleAndInt(double actual, int ignore) {\n        System.out.println(actual);\n    }\n    \n    @BeforeTemplate()\n    void stringAndString(String actual, String ignore) {\n        System.out.println(actual);\n    }\n    \n    @AfterTemplate()\n    void after(Object actual) {\n        System.out.println(\"Changed: \" + actual);\n    }\n}\n```\n.";
+            return "Recipe created for the following Refaster template:\n```java\npublic static class NoUsesTypeWhenBeforeTemplateContainsPrimitiveOrString {\n    \n    @BeforeTemplate()\n    void before(double actual, int ignore) {\n        System.out.println(actual);\n    }\n    \n    @BeforeTemplate()\n    void before(String actual, String ignore) {\n        System.out.println(actual);\n    }\n    \n    @AfterTemplate()\n    void after(Object actual) {\n        System.out.println(\"Changed: \" + actual);\n    }\n}\n```\n.";
         }
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate doubleAndInt = JavaTemplate
+                final JavaTemplate before = JavaTemplate
                         .builder("System.out.println(#{actual:any(double)});")
                         .build();
-                final JavaTemplate stringAndString = JavaTemplate
+                final JavaTemplate before0 = JavaTemplate
                         .builder("System.out.println(#{actual:any(java.lang.String)});")
                         .build();
                 final JavaTemplate after = JavaTemplate
@@ -107,7 +107,7 @@ public class PreconditionsVerifierRecipes extends Recipe {
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = doubleAndInt.matcher(getCursor())).find()) {
+                    if ((matcher = before.matcher(getCursor())).find()) {
                         return embed(
                                 after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
@@ -115,7 +115,7 @@ public class PreconditionsVerifierRecipes extends Recipe {
                                 SHORTEN_NAMES
                         );
                     }
-                    if ((matcher = stringAndString.matcher(getCursor())).find()) {
+                    if ((matcher = before0.matcher(getCursor())).find()) {
                         return embed(
                                 after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
@@ -154,17 +154,17 @@ public class PreconditionsVerifierRecipes extends Recipe {
 
         @Override
         public String getDescription() {
-            return "Recipe created for the following Refaster template:\n```java\npublic static class UsesTypeWhenBeforeTemplateContainsPrimitiveOrStringAndTypeInSomeBeforeBody {\n    \n    @BeforeTemplate()\n    String string(String value) {\n        return Convert.quote(value);\n    }\n    \n    @BeforeTemplate()\n    String _int(int value) {\n        return String.valueOf(value);\n    }\n    \n    @AfterTemplate()\n    Object after(Object actual) {\n        return Convert.quote(String.valueOf(actual));\n    }\n}\n```\n.";
+            return "Recipe created for the following Refaster template:\n```java\npublic static class UsesTypeWhenBeforeTemplateContainsPrimitiveOrStringAndTypeInSomeBeforeBody {\n    \n    @BeforeTemplate()\n    String before(String value) {\n        return Convert.quote(value);\n    }\n    \n    @BeforeTemplate()\n    String before(int value) {\n        return String.valueOf(value);\n    }\n    \n    @AfterTemplate()\n    Object after(Object actual) {\n        return Convert.quote(String.valueOf(actual));\n    }\n}\n```\n.";
         }
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate string = JavaTemplate
+                final JavaTemplate before = JavaTemplate
                         .builder("com.sun.tools.javac.util.Convert.quote(#{value:any(java.lang.String)})")
                         .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
                         .build();
-                final JavaTemplate _int = JavaTemplate
+                final JavaTemplate before0 = JavaTemplate
                         .builder("String.valueOf(#{value:any(int)})")
                         .build();
                 final JavaTemplate after = JavaTemplate
@@ -175,7 +175,7 @@ public class PreconditionsVerifierRecipes extends Recipe {
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = string.matcher(getCursor())).find()) {
+                    if ((matcher = before.matcher(getCursor())).find()) {
                         return embed(
                                 after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
@@ -183,7 +183,7 @@ public class PreconditionsVerifierRecipes extends Recipe {
                                 SHORTEN_NAMES
                         );
                     }
-                    if ((matcher = _int.matcher(getCursor())).find()) {
+                    if ((matcher = before0.matcher(getCursor())).find()) {
                         return embed(
                                 after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
@@ -228,17 +228,17 @@ public class PreconditionsVerifierRecipes extends Recipe {
 
         @Override
         public String getDescription() {
-            return "Recipe created for the following Refaster template:\n```java\npublic static class UsesTypeWhenBeforeTemplateContainsPrimitiveOrStringAndTypeInAllBeforeBody {\n    \n    @BeforeTemplate()\n    String string(String value) {\n        return Convert.quote(value);\n    }\n    \n    @BeforeTemplate()\n    String _int(int value) {\n        return Convert.quote(String.valueOf(value));\n    }\n    \n    @AfterTemplate()\n    Object after(Object actual) {\n        return Convert.quote(String.valueOf(actual));\n    }\n}\n```\n.";
+            return "Recipe created for the following Refaster template:\n```java\npublic static class UsesTypeWhenBeforeTemplateContainsPrimitiveOrStringAndTypeInAllBeforeBody {\n    \n    @BeforeTemplate()\n    String before(String value) {\n        return Convert.quote(value);\n    }\n    \n    @BeforeTemplate()\n    String before(int value) {\n        return Convert.quote(String.valueOf(value));\n    }\n    \n    @AfterTemplate()\n    Object after(Object actual) {\n        return Convert.quote(String.valueOf(actual));\n    }\n}\n```\n.";
         }
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate string = JavaTemplate
+                final JavaTemplate before = JavaTemplate
                         .builder("com.sun.tools.javac.util.Convert.quote(#{value:any(java.lang.String)})")
                         .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
                         .build();
-                final JavaTemplate _int = JavaTemplate
+                final JavaTemplate before0 = JavaTemplate
                         .builder("com.sun.tools.javac.util.Convert.quote(String.valueOf(#{value:any(int)}))")
                         .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
                         .build();
@@ -250,7 +250,7 @@ public class PreconditionsVerifierRecipes extends Recipe {
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = string.matcher(getCursor())).find()) {
+                    if ((matcher = before.matcher(getCursor())).find()) {
                         return embed(
                                 after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
@@ -258,7 +258,7 @@ public class PreconditionsVerifierRecipes extends Recipe {
                                 SHORTEN_NAMES
                         );
                     }
-                    if ((matcher = _int.matcher(getCursor())).find()) {
+                    if ((matcher = before0.matcher(getCursor())).find()) {
                         return embed(
                                 after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
@@ -300,16 +300,16 @@ public class PreconditionsVerifierRecipes extends Recipe {
 
         @Override
         public String getDescription() {
-            return "Recipe created for the following Refaster template:\n```java\npublic static class NoUsesTypeWhenBeforeTemplateContainsPrimitiveAndAnotherType {\n    \n    @BeforeTemplate()\n    void _int(int actual) {\n        System.out.println(actual);\n    }\n    \n    @BeforeTemplate()\n    void map(Map<?, ?> actual) {\n        System.out.println(actual);\n    }\n    \n    @AfterTemplate()\n    void after(Object actual) {\n        System.out.println(\"Changed: \" + actual);\n    }\n}\n```\n.";
+            return "Recipe created for the following Refaster template:\n```java\npublic static class NoUsesTypeWhenBeforeTemplateContainsPrimitiveAndAnotherType {\n    \n    @BeforeTemplate()\n    void before(int actual) {\n        System.out.println(actual);\n    }\n    \n    @BeforeTemplate()\n    void before(Map<?, ?> actual) {\n        System.out.println(actual);\n    }\n    \n    @AfterTemplate()\n    void after(Object actual) {\n        System.out.println(\"Changed: \" + actual);\n    }\n}\n```\n.";
         }
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate _int = JavaTemplate
+                final JavaTemplate before = JavaTemplate
                         .builder("System.out.println(#{actual:any(int)});")
                         .build();
-                final JavaTemplate map = JavaTemplate
+                final JavaTemplate before0 = JavaTemplate
                         .builder("System.out.println(#{actual:any(java.util.Map<?,?>)});")
                         .build();
                 final JavaTemplate after = JavaTemplate
@@ -319,7 +319,7 @@ public class PreconditionsVerifierRecipes extends Recipe {
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = _int.matcher(getCursor())).find()) {
+                    if ((matcher = before.matcher(getCursor())).find()) {
                         return embed(
                                 after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
@@ -327,7 +327,7 @@ public class PreconditionsVerifierRecipes extends Recipe {
                                 SHORTEN_NAMES
                         );
                     }
-                    if ((matcher = map.matcher(getCursor())).find()) {
+                    if ((matcher = before0.matcher(getCursor())).find()) {
                         maybeRemoveImport("java.util.Map");
                         return embed(
                                 after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
@@ -367,16 +367,16 @@ public class PreconditionsVerifierRecipes extends Recipe {
 
         @Override
         public String getDescription() {
-            return "Recipe created for the following Refaster template:\n```java\npublic static class NoUsesTypeWhenBeforeTemplateContainsStringAndAnotherType {\n    \n    @BeforeTemplate()\n    void string(String actual) {\n        System.out.println(actual);\n    }\n    \n    @BeforeTemplate()\n    void map(Map<?, ?> actual) {\n        System.out.println(actual);\n    }\n    \n    @AfterTemplate()\n    void after(Object actual) {\n        System.out.println(\"Changed: \" + actual);\n    }\n}\n```\n.";
+            return "Recipe created for the following Refaster template:\n```java\npublic static class NoUsesTypeWhenBeforeTemplateContainsStringAndAnotherType {\n    \n    @BeforeTemplate()\n    void before(String actual) {\n        System.out.println(actual);\n    }\n    \n    @BeforeTemplate()\n    void before(Map<?, ?> actual) {\n        System.out.println(actual);\n    }\n    \n    @AfterTemplate()\n    void after(Object actual) {\n        System.out.println(\"Changed: \" + actual);\n    }\n}\n```\n.";
         }
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate string = JavaTemplate
+                final JavaTemplate before = JavaTemplate
                         .builder("System.out.println(#{actual:any(java.lang.String)});")
                         .build();
-                final JavaTemplate map = JavaTemplate
+                final JavaTemplate before0 = JavaTemplate
                         .builder("System.out.println(#{actual:any(java.util.Map<?,?>)});")
                         .build();
                 final JavaTemplate after = JavaTemplate
@@ -386,7 +386,7 @@ public class PreconditionsVerifierRecipes extends Recipe {
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = string.matcher(getCursor())).find()) {
+                    if ((matcher = before.matcher(getCursor())).find()) {
                         return embed(
                                 after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
@@ -394,7 +394,7 @@ public class PreconditionsVerifierRecipes extends Recipe {
                                 SHORTEN_NAMES
                         );
                     }
-                    if ((matcher = map.matcher(getCursor())).find()) {
+                    if ((matcher = before0.matcher(getCursor())).find()) {
                         maybeRemoveImport("java.util.Map");
                         return embed(
                                 after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
@@ -503,16 +503,16 @@ public class PreconditionsVerifierRecipes extends Recipe {
 
         @Override
         public String getDescription() {
-            return "Recipe created for the following Refaster template:\n```java\npublic static class UsesTypeMapOrListWhenBeforeTemplateContainsMapAndList {\n    \n    @BeforeTemplate()\n    void list(List<?> actual) {\n        System.out.println(actual);\n    }\n    \n    @BeforeTemplate()\n    void map(Map<?, ?> actual) {\n        System.out.println(actual);\n    }\n    \n    @AfterTemplate()\n    void after(Object actual) {\n        System.out.println(\"Changed: \" + actual);\n    }\n}\n```\n.";
+            return "Recipe created for the following Refaster template:\n```java\npublic static class UsesTypeMapOrListWhenBeforeTemplateContainsMapAndList {\n    \n    @BeforeTemplate()\n    void before(List<?> actual) {\n        System.out.println(actual);\n    }\n    \n    @BeforeTemplate()\n    void before(Map<?, ?> actual) {\n        System.out.println(actual);\n    }\n    \n    @AfterTemplate()\n    void after(Object actual) {\n        System.out.println(\"Changed: \" + actual);\n    }\n}\n```\n.";
         }
 
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate list = JavaTemplate
+                final JavaTemplate before = JavaTemplate
                         .builder("System.out.println(#{actual:any(java.util.List<?>)});")
                         .build();
-                final JavaTemplate map = JavaTemplate
+                final JavaTemplate before0 = JavaTemplate
                         .builder("System.out.println(#{actual:any(java.util.Map<?,?>)});")
                         .build();
                 final JavaTemplate after = JavaTemplate
@@ -522,7 +522,7 @@ public class PreconditionsVerifierRecipes extends Recipe {
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = list.matcher(getCursor())).find()) {
+                    if ((matcher = before.matcher(getCursor())).find()) {
                         maybeRemoveImport("java.util.List");
                         return embed(
                                 after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
@@ -531,7 +531,7 @@ public class PreconditionsVerifierRecipes extends Recipe {
                                 SHORTEN_NAMES
                         );
                     }
-                    if ((matcher = map.matcher(getCursor())).find()) {
+                    if ((matcher = before0.matcher(getCursor())).find()) {
                         maybeRemoveImport("java.util.Map");
                         return embed(
                                 after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),


### PR DESCRIPTION
## What's changed?
After
- https://github.com/openrewrite/rewrite-templating/pull/120

we should be able to create fitting preconditions with multiple @BeforeTemplates (so no breaking `UsesType` when not all @BeforeTemplate use that type, as mentioned in https://github.com/openrewrite/rewrite-templating/issues/119). But the code did not work for overloaded methods, because the key/value in a temporary precondition-map was replaced by the next overloaded method.

## What's your motivation?
- https://github.com/PicnicSupermarket/error-prone-support/pull/1470#pullrequestreview-2515089902

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
