### PR TITLE
Tweak how JavaDoc is converted into displayName/description

### DIFF
--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -493,11 +493,14 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                             .replace("\f", "\\f")
                             .replace("\r", "\\r");
                     String[] lines = commentText.split("\\.\\R+", 2);
-                    displayName = lines[0].trim().replace("\n", "");
-                    if (displayName.endsWith(".")) {
-                        displayName = displayName.substring(0, displayName.length() - 1);
+                    String firstLine = lines[0].trim().replace("\n", "");
+                    if (firstLine.endsWith(".")) {
+                        firstLine = firstLine.substring(0, firstLine.length() - 1);
                     }
-                    if (lines.length > 1 && !lines[1].trim().isEmpty()) {
+                    if (lines.length == 1 || lines[1].trim().isEmpty()) {
+                        description = new StringBuilder(firstLine);
+                    } else {
+                        displayName = firstLine;
                         description = new StringBuilder(lines[1].trim().replace("\n", "\\n"));
                         if (!description.toString().endsWith(".")) {
                             description.append('.');

--- a/src/test/resources/refaster/PicnicRules.java
+++ b/src/test/resources/refaster/PicnicRules.java
@@ -19,9 +19,67 @@ import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
+/**
+ * Picnic rules for refaster, showing how JavaDoc is converted to Markdown.
+ */
 @OnlineDocumentation
 public class PicnicRules {
-    public static class NestedRule {
+    /**
+     * A single line used as description.
+     */
+    public static class FirstRule {
+        @BeforeTemplate
+        String before(String s, String s1, String s2) {
+            return s.replaceAll(s1, s2);
+        }
+
+        @AfterTemplate
+        String after(String s, String s1, String s2) {
+            return s != null ? s.replaceAll(s1, s2) : s;
+        }
+    }
+
+    /**
+     * A continuation line,
+     * used as a description.
+     */
+    public static class SecondRule {
+        @BeforeTemplate
+        String before(String s, String s1, String s2) {
+            return s.replaceAll(s1, s2);
+        }
+
+        @AfterTemplate
+        String after(String s, String s1, String s2) {
+            return s != null ? s.replaceAll(s1, s2) : s;
+        }
+    }
+
+    /**
+     * A first line as displayName.
+     *
+     * A second line as description.
+     */
+    public static class ThirdRule {
+        @BeforeTemplate
+        String before(String s, String s1, String s2) {
+            return s.replaceAll(s1, s2);
+        }
+
+        @AfterTemplate
+        String after(String s, String s1, String s2) {
+            return s != null ? s.replaceAll(s1, s2) : s;
+        }
+    }
+
+    /**
+     * A continuation line,
+     * used as a description.
+     *
+     * A second line
+     * as description.
+     */
+    public static class FourthRule {
         @BeforeTemplate
         String before(String s, String s1, String s2) {
             return s.replaceAll(s1, s2);

--- a/src/test/resources/refaster/PicnicRules.java
+++ b/src/test/resources/refaster/PicnicRules.java
@@ -90,4 +90,17 @@ public class PicnicRules {
             return s != null ? s.replaceAll(s1, s2) : s;
         }
     }
+
+    // No JavaDoc
+    public static class FifthRule {
+        @BeforeTemplate
+        String before(String s, String s1, String s2) {
+            return s.replaceAll(s1, s2);
+        }
+
+        @AfterTemplate
+        String after(String s, String s1, String s2) {
+            return s != null ? s.replaceAll(s1, s2) : s;
+        }
+    }
 }

--- a/src/test/resources/refaster/PicnicRulesRecipes.java
+++ b/src/test/resources/refaster/PicnicRulesRecipes.java
@@ -61,7 +61,8 @@ public class PicnicRulesRecipes extends Recipe {
                 new FirstRuleRecipe(),
                 new SecondRuleRecipe(),
                 new ThirdRuleRecipe(),
-                new FourthRuleRecipe()
+                new FourthRuleRecipe(),
+                new FifthRuleRecipe()
         );
     }
 
@@ -251,6 +252,61 @@ public class PicnicRulesRecipes extends Recipe {
         @Override
         public String getDescription() {
             return "A second line\n as description.";
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor() {
+            JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
+                final JavaTemplate before = JavaTemplate
+                        .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
+                        .build();
+                final JavaTemplate after = JavaTemplate
+                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
+                        .build();
+
+                @Override
+                public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
+                    JavaTemplate.Matcher matcher;
+                    if ((matcher = before.matcher(getCursor())).find()) {
+                        return embed(
+                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
+                                getCursor(),
+                                ctx,
+                                SHORTEN_NAMES, SIMPLIFY_BOOLEANS
+                        );
+                    }
+                    return super.visitMethodInvocation(elem, ctx);
+                }
+
+            };
+            return Preconditions.check(
+                    new UsesMethod<>("java.lang.String replaceAll(..)", true),
+                    javaVisitor
+            );
+        }
+    }
+
+    /**
+     * OpenRewrite recipe created for Refaster template {@code PicnicRules.FifthRule}.
+     */
+    @SuppressWarnings("all")
+    @NullMarked
+    @Generated("org.openrewrite.java.template.processor.RefasterTemplateProcessor")
+    public static class FifthRuleRecipe extends Recipe {
+
+        /**
+         * Instantiates a new instance.
+         */
+        public FifthRuleRecipe() {}
+
+        @Override
+        public String getDisplayName() {
+            return "Refaster template `PicnicRules.FifthRule`";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Recipe created for the following Refaster template:\n```java\npublic static class FifthRule {\n    \n    @BeforeTemplate()\n    String before(String s, String s1, String s2) {\n        return s.replaceAll(s1, s2);\n    }\n    \n    @AfterTemplate()\n    String after(String s, String s1, String s2) {\n        return s != null ? s.replaceAll(s1, s2) : s;\n    }\n}\n```\n.";
         }
 
         @Override

--- a/src/test/resources/refaster/PicnicRulesRecipes.java
+++ b/src/test/resources/refaster/PicnicRulesRecipes.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package foo;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/test/resources/refaster/PicnicRulesRecipes.java
+++ b/src/test/resources/refaster/PicnicRulesRecipes.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2024 the original author or authors.
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * <p>
- * https://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package foo;
 
 import org.jspecify.annotations.NullMarked;
@@ -52,37 +37,205 @@ public class PicnicRulesRecipes extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Refaster template recipes for `foo.PicnicRules`. [Source](https://error-prone.picnic.tech/refasterrules/PicnicRules).";
+        return "Picnic rules for refaster, showing how JavaDoc is converted to Markdown [Source](https://error-prone.picnic.tech/refasterrules/PicnicRules).";
     }
 
     @Override
     public List<Recipe> getRecipeList() {
         return Arrays.asList(
-                new NestedRuleRecipe()
+                new FirstRuleRecipe(),
+                new SecondRuleRecipe(),
+                new ThirdRuleRecipe(),
+                new FourthRuleRecipe()
         );
     }
 
     /**
-     * OpenRewrite recipe created for Refaster template {@code PicnicRules.NestedRule}.
+     * OpenRewrite recipe created for Refaster template {@code PicnicRules.FirstRule}.
      */
     @SuppressWarnings("all")
     @NullMarked
     @Generated("org.openrewrite.java.template.processor.RefasterTemplateProcessor")
-    public static class NestedRuleRecipe extends Recipe {
+    public static class FirstRuleRecipe extends Recipe {
 
         /**
          * Instantiates a new instance.
          */
-        public NestedRuleRecipe() {}
+        public FirstRuleRecipe() {}
 
         @Override
         public String getDisplayName() {
-            return "Refaster template `PicnicRules.NestedRule`";
+            return "Refaster template `PicnicRules.FirstRule`";
         }
 
         @Override
         public String getDescription() {
-            return "Recipe created for the following Refaster template:\n```java\npublic static class NestedRule {\n    \n    @BeforeTemplate()\n    String before(String s, String s1, String s2) {\n        return s.replaceAll(s1, s2);\n    }\n    \n    @AfterTemplate()\n    String after(String s, String s1, String s2) {\n        return s != null ? s.replaceAll(s1, s2) : s;\n    }\n}\n```\n.";
+            return "A single line used as description";
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor() {
+            JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
+                final JavaTemplate before = JavaTemplate
+                        .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
+                        .build();
+                final JavaTemplate after = JavaTemplate
+                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
+                        .build();
+
+                @Override
+                public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
+                    JavaTemplate.Matcher matcher;
+                    if ((matcher = before.matcher(getCursor())).find()) {
+                        return embed(
+                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
+                                getCursor(),
+                                ctx,
+                                SHORTEN_NAMES, SIMPLIFY_BOOLEANS
+                        );
+                    }
+                    return super.visitMethodInvocation(elem, ctx);
+                }
+
+            };
+            return Preconditions.check(
+                    new UsesMethod<>("java.lang.String replaceAll(..)", true),
+                    javaVisitor
+            );
+        }
+    }
+
+    /**
+     * OpenRewrite recipe created for Refaster template {@code PicnicRules.SecondRule}.
+     */
+    @SuppressWarnings("all")
+    @NullMarked
+    @Generated("org.openrewrite.java.template.processor.RefasterTemplateProcessor")
+    public static class SecondRuleRecipe extends Recipe {
+
+        /**
+         * Instantiates a new instance.
+         */
+        public SecondRuleRecipe() {}
+
+        @Override
+        public String getDisplayName() {
+            return "Refaster template `PicnicRules.SecondRule`";
+        }
+
+        @Override
+        public String getDescription() {
+            return "A continuation line, used as a description";
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor() {
+            JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
+                final JavaTemplate before = JavaTemplate
+                        .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
+                        .build();
+                final JavaTemplate after = JavaTemplate
+                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
+                        .build();
+
+                @Override
+                public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
+                    JavaTemplate.Matcher matcher;
+                    if ((matcher = before.matcher(getCursor())).find()) {
+                        return embed(
+                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
+                                getCursor(),
+                                ctx,
+                                SHORTEN_NAMES, SIMPLIFY_BOOLEANS
+                        );
+                    }
+                    return super.visitMethodInvocation(elem, ctx);
+                }
+
+            };
+            return Preconditions.check(
+                    new UsesMethod<>("java.lang.String replaceAll(..)", true),
+                    javaVisitor
+            );
+        }
+    }
+
+    /**
+     * OpenRewrite recipe created for Refaster template {@code PicnicRules.ThirdRule}.
+     */
+    @SuppressWarnings("all")
+    @NullMarked
+    @Generated("org.openrewrite.java.template.processor.RefasterTemplateProcessor")
+    public static class ThirdRuleRecipe extends Recipe {
+
+        /**
+         * Instantiates a new instance.
+         */
+        public ThirdRuleRecipe() {}
+
+        @Override
+        public String getDisplayName() {
+            return "A first line as displayName";
+        }
+
+        @Override
+        public String getDescription() {
+            return "A second line as description.";
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor() {
+            JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
+                final JavaTemplate before = JavaTemplate
+                        .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
+                        .build();
+                final JavaTemplate after = JavaTemplate
+                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
+                        .build();
+
+                @Override
+                public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
+                    JavaTemplate.Matcher matcher;
+                    if ((matcher = before.matcher(getCursor())).find()) {
+                        return embed(
+                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
+                                getCursor(),
+                                ctx,
+                                SHORTEN_NAMES, SIMPLIFY_BOOLEANS
+                        );
+                    }
+                    return super.visitMethodInvocation(elem, ctx);
+                }
+
+            };
+            return Preconditions.check(
+                    new UsesMethod<>("java.lang.String replaceAll(..)", true),
+                    javaVisitor
+            );
+        }
+    }
+
+    /**
+     * OpenRewrite recipe created for Refaster template {@code PicnicRules.FourthRule}.
+     */
+    @SuppressWarnings("all")
+    @NullMarked
+    @Generated("org.openrewrite.java.template.processor.RefasterTemplateProcessor")
+    public static class FourthRuleRecipe extends Recipe {
+
+        /**
+         * Instantiates a new instance.
+         */
+        public FourthRuleRecipe() {}
+
+        @Override
+        public String getDisplayName() {
+            return "A continuation line, used as a description";
+        }
+
+        @Override
+        public String getDescription() {
+            return "A second line\n as description.";
         }
 
         @Override

--- a/src/test/resources/refaster/PreconditionsVerifierRecipes.java
+++ b/src/test/resources/refaster/PreconditionsVerifierRecipes.java
@@ -47,12 +47,12 @@ public class PreconditionsVerifierRecipes extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "A refaster template to test when a `UsesType`and Preconditions.or should or should not be applied to the Preconditions check";
+        return "`PreconditionsVerifier` Refaster recipes";
     }
 
     @Override
     public String getDescription() {
-        return "Refaster template recipes for `foo.PreconditionsVerifier`.";
+        return "A refaster template to test when a `UsesType`and Preconditions.or should or should not be applied to the Preconditions check";
     }
 
     @Override


### PR DESCRIPTION
## What's changed?
Now set either description or displayName + description, but drop the longer generated description where possibe.

## What's your motivation?
Previously we would often retain the generated Markdown that merely showed the input template, whereas there's JavaDoc comments that would be a better fit and make the docs more readable. 