### PR TITLE
Fix issue #126 @Matches applies to the wrong parameter

### DIFF
--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -26,6 +26,7 @@ import com.sun.tools.javac.parser.Tokens;
 import com.sun.tools.javac.tree.*;
 import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.Name;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.java.template.internal.ImportDetector;
 import org.openrewrite.java.template.internal.JavacResolution;
@@ -46,6 +47,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.singletonList;
@@ -383,23 +385,25 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
 
                 visitMethod.append("                JavaTemplate.Matcher matcher;\n");
                 for (Map.Entry<String, TemplateDescriptor> entry : beforeTemplates.entrySet()) {
+                    Map<Name, Integer> beforeParameters = findParameterOrder(entry.getValue().method);
                     int arity = entry.getValue().getArity();
                     for (int i = 0; i < arity; i++) {
                         visitMethod.append("                if (" + "(matcher = ").append(entry.getKey()).append(arity > 1 ? "$" + i : "").append(".matcher(getCursor())).find()").append(") {\n");
                         com.sun.tools.javac.util.List<JCTree.JCVariableDecl> jcVariableDecls = entry.getValue().method.getParameters();
                         for (int j = 0; j < jcVariableDecls.size(); j++) {
                             JCTree.JCVariableDecl param = jcVariableDecls.get(j);
+                            int index = beforeParameters.getOrDefault(param.name, -1);
                             com.sun.tools.javac.util.List<JCTree.JCAnnotation> annotations = param.getModifiers().getAnnotations();
                             for (JCTree.JCAnnotation jcAnnotation : annotations) {
                                 String annotationType = jcAnnotation.attribute.type.tsym.getQualifiedName().toString();
                                 if (annotationType.equals("org.openrewrite.java.template.NotMatches")) {
                                     String matcher = ((Type.ClassType) jcAnnotation.attribute.getValue().values.get(0).snd.getValue()).tsym.getQualifiedName().toString();
-                                    visitMethod.append("                    if (new ").append(matcher).append("().matches((Expression) matcher.parameter(").append(j).append("))) {\n");
+                                    visitMethod.append("                    if (new ").append(matcher).append("().matches((Expression) matcher.parameter(").append(index).append("))) {\n");
                                     visitMethod.append("                        return super.visit").append(methodSuffix).append("(elem, ctx);\n");
                                     visitMethod.append("                    }\n");
                                 } else if (annotationType.equals("org.openrewrite.java.template.Matches")) {
                                     String matcher = ((Type.ClassType) jcAnnotation.attribute.getValue().values.get(0).snd.getValue()).tsym.getQualifiedName().toString();
-                                    visitMethod.append("                    if (!new ").append(matcher).append("().matches((Expression) matcher.parameter(").append(j).append("))) {\n");
+                                    visitMethod.append("                    if (!new ").append(matcher).append("().matches((Expression) matcher.parameter(").append(index).append("))) {\n");
                                     visitMethod.append("                        return super.visit").append(methodSuffix).append("(elem, ctx);\n");
                                     visitMethod.append("                    }\n");
                                 }
@@ -426,7 +430,8 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
 
                             visitMethod.append("                    return embed(\n");
                             visitMethod.append("                            ").append(after).append(".apply(getCursor(), elem.getCoordinates().replace()");
-                            String parameters = parameters(entry.getValue(), descriptor);
+                            Map<Name, Integer> afterParameters = findParameterOrder(descriptor.afterTemplate.method);
+                            String parameters = matchParameters(beforeParameters, afterParameters);
                             if (!parameters.isEmpty()) {
                                 visitMethod.append(", ").append(parameters);
                             }
@@ -647,10 +652,9 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
         return string.replace("\\", "\\\\").replace("\"", "\\\"").replaceAll("\\R", "\\\\n");
     }
 
-    private String parameters(TemplateDescriptor before, RuleDescriptor descriptor) {
+    private Map<Name, Integer> findParameterOrder(JCTree.JCMethodDecl method) {
         AtomicInteger beforeParameterOccurrence = new AtomicInteger();
-        Map<Integer, Integer> beforeParamOrder = new HashMap<>();
-        List<Integer> afterParams = new ArrayList<>();
+        Map<Name, Integer> beforeParamOrder = new HashMap<>();
         Set<Symbol> seenParams = new HashSet<>();
         new TreeScanner() {
             @Override
@@ -661,36 +665,20 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                         jcIdent.sym.owner instanceof Symbol.MethodSymbol &&
                         ((Symbol.MethodSymbol) jcIdent.sym.owner).params.contains(jcIdent.sym) &&
                         seenParams.add(jcIdent.sym)) {
-                        beforeParamOrder.put(((Symbol.MethodSymbol) jcIdent.sym.owner).params.indexOf(jcIdent.sym), beforeParameterOccurrence.getAndIncrement());
+                        beforeParamOrder.put(jcIdent.sym.name, beforeParameterOccurrence.getAndIncrement());
                     }
                 }
                 super.scan(jcTree);
             }
-        }.scan(before.method.body);
+        }.scan(method);
+        return beforeParamOrder;
+    }
 
-        if (descriptor.afterTemplate != null) {
-            new TreeScanner() {
-                @Override
-                public void scan(JCTree jcTree) {
-                    if (jcTree instanceof JCTree.JCIdent) {
-                        JCTree.JCIdent jcIdent = (JCTree.JCIdent) jcTree;
-                        if (jcIdent.sym instanceof Symbol.VarSymbol &&
-                            jcIdent.sym.owner instanceof Symbol.MethodSymbol &&
-                            ((Symbol.MethodSymbol) jcIdent.sym.owner).params.contains(jcIdent.sym) &&
-                            seenParams.add(jcIdent.sym)) {
-                            afterParams.add(beforeParamOrder.get(((Symbol.MethodSymbol) jcIdent.sym.owner).params.indexOf(jcIdent.sym)));
-                        }
-                    }
-                    super.scan(jcTree);
-                }
-            }.scan(descriptor.afterTemplate.method.body);
-        }
-
-        StringJoiner joiner = new StringJoiner(", ");
-        for (Integer param : afterParams) {
-            joiner.add("matcher.parameter(" + param + ")");
-        }
-        return joiner.toString();
+    private String matchParameters(Map<Name, Integer> beforeParameters, Map<Name, Integer> afterParameters) {
+        return afterParameters.entrySet().stream().sorted(Map.Entry.comparingByValue())
+                .map(e -> beforeParameters.getOrDefault(e.getKey(), -1))
+                .map(e -> "matcher.parameter(" + e + ")")
+                .collect(Collectors.joining(", "));
     }
 
     private Class<? extends JCTree> getType(JCTree.JCMethodDecl method) {

--- a/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
@@ -50,6 +50,7 @@ class RefasterTemplateProcessorTest {
       "MethodThrows",
       "NestedPreconditions",
       "NewBufferedWriter",
+      "ParameterOrder",
       "UseStringIsEmpty",
       "SimplifyBooleans",
       "TwoVisitMethods",
@@ -114,6 +115,33 @@ class RefasterTemplateProcessorTest {
         assertThat(compilation).succeeded();
         assertThat(compilation).hadNoteContaining("Method references are currently not supported");
         assertEquals(0, compilation.generatedSourceFiles().size(), "Not yet supported");
+    }
+
+    @Test
+    void missingArguments() {
+        Compilation compilation = compileResource("refaster/MissingArguments.java");
+        assertThat(compilation).succeeded();
+        assertThat(compilation).hadNoteContaining("@AfterTemplate defines arguments that are not present in all @BeforeTemplate methods");
+        assertEquals(0, compilation.generatedSourceFiles().size(), "Must not generate recipe for missing arguments");
+    }
+
+    @Test
+    void extraArguments() {
+        Compilation compilation = compileResource("refaster/ExtraArguments.java");
+        assertThat(compilation).succeeded();
+        assertEquals(1, compilation.generatedSourceFiles().size(), "Must generate recipe for discarded arguments");
+    }
+
+    @Test
+    void annotatedUnusedArgument() {
+        Compilation compilation = compileResource("refaster/AnnotatedUnusedArgument.java");
+        assertThat(compilation).succeeded();
+        assertThat(compilation).hadNoteContaining("Ignoring annotation org.openrewrite.java.template.Matches on unused parameter b");
+        assertThat(compilation).hadNoteContaining("Ignoring annotation org.openrewrite.java.template.NotMatches on unused parameter c");
+        assertEquals(1, compilation.generatedSourceFiles().size(), "Should warn but generate recipe for discarded arguments");
+        assertThat(compilation)
+          .generatedSourceFile("foo/AnnotatedUnusedArgumentRecipe")
+          .hasSourceEquivalentTo(JavaFileObjects.forResource("refaster/AnnotatedUnusedArgumentRecipe.java"));
     }
 
     @Test

--- a/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
+++ b/src/test/java/org/openrewrite/java/template/RefasterTemplateProcessorTest.java
@@ -46,6 +46,7 @@ class RefasterTemplateProcessorTest {
     @ValueSource(strings = {
       "Arrays",
       "CharacterEscapeAnnotation",
+      "MatchOrder",
       "MethodThrows",
       "NestedPreconditions",
       "NewBufferedWriter",

--- a/src/test/resources/refaster/AnnotatedUnusedArgument.java
+++ b/src/test/resources/refaster/AnnotatedUnusedArgument.java
@@ -18,23 +18,22 @@ package foo;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import org.openrewrite.java.template.Matches;
-import org.openrewrite.java.template.MethodInvocationMatcher;
 import org.openrewrite.java.template.NotMatches;
+import org.openrewrite.java.template.MethodInvocationMatcher;
 
-public class MatchOrder {
-
+public class AnnotatedUnusedArgument {
     @BeforeTemplate
-    boolean before1(@Matches(MethodInvocationMatcher.class) String literal, @NotMatches(MethodInvocationMatcher.class) String str) {
-        return str.equals(literal);
+    public int before1(int a, @Matches(MethodInvocationMatcher.class) int b) {
+        return a;
     }
 
     @BeforeTemplate
-    boolean before2(@NotMatches(MethodInvocationMatcher.class) String str, @Matches(MethodInvocationMatcher.class) String literal) {
-        return str.equals(literal);
+    public int before2(int a, @NotMatches(MethodInvocationMatcher.class) int c) {
+        return a;
     }
 
     @AfterTemplate
-    boolean after(String literal, String str) {
-        return literal.equals(str);
+    public int after(int a) {
+        return a;
     }
 }

--- a/src/test/resources/refaster/AnnotatedUnusedArgumentRecipe.java
+++ b/src/test/resources/refaster/AnnotatedUnusedArgumentRecipe.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package foo;
+
+import org.jspecify.annotations.NullMarked;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.search.*;
+import org.openrewrite.java.template.Primitive;
+import org.openrewrite.java.template.function.*;
+import org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor;
+import org.openrewrite.java.tree.*;
+
+import javax.annotation.Generated;
+import java.util.*;
+
+import static org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor.EmbeddingOption.*;
+
+/**
+ * OpenRewrite recipe created for Refaster template {@code AnnotatedUnusedArgument}.
+ */
+@SuppressWarnings("all")
+@NullMarked
+@Generated("org.openrewrite.java.template.processor.RefasterTemplateProcessor")
+public class AnnotatedUnusedArgumentRecipe extends Recipe {
+
+    /**
+     * Instantiates a new instance.
+     */
+    public AnnotatedUnusedArgumentRecipe() {}
+
+    @Override
+    public String getDisplayName() {
+        //language=markdown
+        return "Refaster template `AnnotatedUnusedArgument`";
+    }
+
+    @Override
+    public String getDescription() {
+        //language=markdown
+        return "Recipe created for the following Refaster template:\n```java\npublic class AnnotatedUnusedArgument {\n    \n    @BeforeTemplate()\n    public int before1(int a, @Matches(value = MethodInvocationMatcher.class)\n    int b) {\n        return a;\n    }\n    \n    @BeforeTemplate()\n    public int before2(int a, @NotMatches(value = MethodInvocationMatcher.class)\n    int c) {\n        return a;\n    }\n    \n    @AfterTemplate()\n    public int after(int a) {\n        return a;\n    }\n}\n```\n.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new AbstractRefasterJavaVisitor() {
+            final JavaTemplate before1 = JavaTemplate
+                    .builder("#{a:any(int)}")
+                    .build();
+            final JavaTemplate before2 = JavaTemplate
+                    .builder("#{a:any(int)}")
+                    .build();
+            final JavaTemplate after = JavaTemplate
+                    .builder("#{a:any(int)}")
+                    .build();
+
+            @Override
+            public J visitExpression(Expression elem, ExecutionContext ctx) {
+                JavaTemplate.Matcher matcher;
+                if ((matcher = before2.matcher(getCursor())).find()) {
+                    return embed(
+                            after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                            getCursor(),
+                            ctx,
+                            SHORTEN_NAMES
+                    );
+                }
+                if ((matcher = before1.matcher(getCursor())).find()) {
+                    return embed(
+                            after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                            getCursor(),
+                            ctx,
+                            SHORTEN_NAMES
+                    );
+                }
+                return super.visitExpression(elem, ctx);
+            }
+
+        };
+    }
+}

--- a/src/test/resources/refaster/ExtraArguments.java
+++ b/src/test/resources/refaster/ExtraArguments.java
@@ -17,24 +17,15 @@ package foo;
 
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
-import org.openrewrite.java.template.Matches;
-import org.openrewrite.java.template.MethodInvocationMatcher;
-import org.openrewrite.java.template.NotMatches;
 
-public class MatchOrder {
-
+public class ExtraArguments {
     @BeforeTemplate
-    boolean before1(@Matches(MethodInvocationMatcher.class) String literal, @NotMatches(MethodInvocationMatcher.class) String str) {
-        return str.equals(literal);
-    }
-
-    @BeforeTemplate
-    boolean before2(@NotMatches(MethodInvocationMatcher.class) String str, @Matches(MethodInvocationMatcher.class) String literal) {
-        return str.equals(literal);
+    public int before(int a, int b) {
+        return a + b;
     }
 
     @AfterTemplate
-    boolean after(String literal, String str) {
-        return literal.equals(str);
+    public int after(int a) {
+        return a;
     }
 }

--- a/src/test/resources/refaster/MatchOrder.java
+++ b/src/test/resources/refaster/MatchOrder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package foo;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import org.openrewrite.java.template.Matches;
+import org.openrewrite.java.template.MethodInvocationMatcher;
+import org.openrewrite.java.template.NotMatches;
+
+public class MatchOrder {
+
+    @BeforeTemplate
+    boolean before1(@Matches(MethodInvocationMatcher.class) String literal, @NotMatches(MethodInvocationMatcher.class) String str) {
+        return str.equals(literal);
+    }
+
+    @BeforeTemplate
+    boolean before2(@NotMatches(MethodInvocationMatcher.class) String str, @Matches(MethodInvocationMatcher.class) String literal) {
+        return str.equals(literal);
+    }
+
+    @AfterTemplate
+    boolean after(String literal, String str) {
+        return literal.equals(str);
+    }
+}

--- a/src/test/resources/refaster/MatchOrderRecipe.java
+++ b/src/test/resources/refaster/MatchOrderRecipe.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package foo;
+
+import org.jspecify.annotations.NullMarked;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.search.*;
+import org.openrewrite.java.template.Primitive;
+import org.openrewrite.java.template.function.*;
+import org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor;
+import org.openrewrite.java.tree.*;
+
+import javax.annotation.Generated;
+import java.util.*;
+
+import static org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor.EmbeddingOption.*;
+
+/**
+ * OpenRewrite recipe created for Refaster template {@code MatchOrder}.
+ */
+@SuppressWarnings("all")
+@NullMarked
+@Generated("org.openrewrite.java.template.processor.RefasterTemplateProcessor")
+public class MatchOrderRecipe extends Recipe {
+
+    /**
+     * Instantiates a new instance.
+     */
+    public MatchOrderRecipe() {}
+
+    @Override
+    public String getDisplayName() {
+        //language=markdown
+        return "Refaster template `MatchOrder`";
+    }
+
+    @Override
+    public String getDescription() {
+        //language=markdown
+        return "Recipe created for the following Refaster template:\n```java\npublic class MatchOrder {\n    \n    @BeforeTemplate()\n    boolean before1(@Matches(value = MethodInvocationMatcher.class)\n    String literal, @NotMatches(value = MethodInvocationMatcher.class)\n    String str) {\n        return str.equals(literal);\n    }\n    \n    @BeforeTemplate()\n    boolean before2(@NotMatches(value = MethodInvocationMatcher.class)\n    String str, @Matches(value = MethodInvocationMatcher.class)\n    String literal) {\n        return str.equals(literal);\n    }\n    \n    @AfterTemplate()\n    boolean after(String literal, String str) {\n        return literal.equals(str);\n    }\n}\n```\n.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
+            final JavaTemplate before1 = JavaTemplate
+                    .builder("#{str:any(java.lang.String)}.equals(#{literal:any(java.lang.String)})")
+                    .build();
+            final JavaTemplate before2 = JavaTemplate
+                    .builder("#{str:any(java.lang.String)}.equals(#{literal:any(java.lang.String)})")
+                    .build();
+            final JavaTemplate after = JavaTemplate
+                    .builder("#{literal:any(java.lang.String)}.equals(#{str:any(java.lang.String)})")
+                    .build();
+
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
+                JavaTemplate.Matcher matcher;
+                if ((matcher = before2.matcher(getCursor())).find()) {
+                    if (new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(0))) {
+                        return super.visitMethodInvocation(elem, ctx);
+                    }
+                    if (!new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(1))) {
+                        return super.visitMethodInvocation(elem, ctx);
+                    }
+                    return embed(
+                            after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(1), matcher.parameter(0)),
+                            getCursor(),
+                            ctx,
+                            SHORTEN_NAMES, SIMPLIFY_BOOLEANS
+                    );
+                }
+                if ((matcher = before1.matcher(getCursor())).find()) {
+                    if (!new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(1))) {
+                        return super.visitMethodInvocation(elem, ctx);
+                    }
+                    if (new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(0))) {
+                        return super.visitMethodInvocation(elem, ctx);
+                    }
+                    return embed(
+                            after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(1), matcher.parameter(0)),
+                            getCursor(),
+                            ctx,
+                            SHORTEN_NAMES, SIMPLIFY_BOOLEANS
+                    );
+                }
+                return super.visitMethodInvocation(elem, ctx);
+            }
+
+        };
+        return Preconditions.check(
+                new UsesMethod<>("java.lang.String equals(..)", true),
+                javaVisitor
+        );
+    }
+}

--- a/src/test/resources/refaster/MatchOrderRecipe.java
+++ b/src/test/resources/refaster/MatchOrderRecipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/refaster/MatchingRecipes.java
+++ b/src/test/resources/refaster/MatchingRecipes.java
@@ -112,7 +112,7 @@ public class MatchingRecipes extends Recipe {
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before.matcher(getCursor())).find()) {
-                        if (new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(1))) {
+                        if (new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(0))) {
                             return super.visitMethodInvocation(elem, ctx);
                         }
                         return embed(
@@ -123,7 +123,7 @@ public class MatchingRecipes extends Recipe {
                         );
                     }
                     if ((matcher = before2.matcher(getCursor())).find()) {
-                        if (!new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(1))) {
+                        if (!new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(0))) {
                             return super.visitMethodInvocation(elem, ctx);
                         }
                         return embed(

--- a/src/test/resources/refaster/MissingArguments.java
+++ b/src/test/resources/refaster/MissingArguments.java
@@ -17,24 +17,20 @@ package foo;
 
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
-import org.openrewrite.java.template.Matches;
-import org.openrewrite.java.template.MethodInvocationMatcher;
-import org.openrewrite.java.template.NotMatches;
 
-public class MatchOrder {
-
+public class MissingArguments {
     @BeforeTemplate
-    boolean before1(@Matches(MethodInvocationMatcher.class) String literal, @NotMatches(MethodInvocationMatcher.class) String str) {
-        return str.equals(literal);
+    public int before1(int a, int b) {
+        return a + b;
     }
 
     @BeforeTemplate
-    boolean before2(@NotMatches(MethodInvocationMatcher.class) String str, @Matches(MethodInvocationMatcher.class) String literal) {
-        return str.equals(literal);
+    public int before2(int a, int c) {
+        return a + c;
     }
 
     @AfterTemplate
-    boolean after(String literal, String str) {
-        return literal.equals(str);
+    public int after(int a, int b, int c) {
+        return a + b + c;
     }
 }

--- a/src/test/resources/refaster/ParameterOrder.java
+++ b/src/test/resources/refaster/ParameterOrder.java
@@ -17,24 +17,15 @@ package foo;
 
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
-import org.openrewrite.java.template.Matches;
-import org.openrewrite.java.template.MethodInvocationMatcher;
-import org.openrewrite.java.template.NotMatches;
 
-public class MatchOrder {
-
+public class ParameterOrder {
     @BeforeTemplate
-    boolean before1(@Matches(MethodInvocationMatcher.class) String literal, @NotMatches(MethodInvocationMatcher.class) String str) {
-        return str.equals(literal);
-    }
-
-    @BeforeTemplate
-    boolean before2(@NotMatches(MethodInvocationMatcher.class) String str, @Matches(MethodInvocationMatcher.class) String literal) {
-        return str.equals(literal);
+    public int parameters(int b, int a) {
+        return a + b;
     }
 
     @AfterTemplate
-    boolean after(String literal, String str) {
-        return literal.equals(str);
+    public int output(int a, int b) {
+        return a + a + b;
     }
 }

--- a/src/test/resources/refaster/ParameterOrderRecipe.java
+++ b/src/test/resources/refaster/ParameterOrderRecipe.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package foo;
+
+import org.jspecify.annotations.NullMarked;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.search.*;
+import org.openrewrite.java.template.Primitive;
+import org.openrewrite.java.template.function.*;
+import org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor;
+import org.openrewrite.java.tree.*;
+
+import javax.annotation.Generated;
+import java.util.*;
+
+import static org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor.EmbeddingOption.*;
+
+/**
+ * OpenRewrite recipe created for Refaster template {@code ParameterOrder}.
+ */
+@SuppressWarnings("all")
+@NullMarked
+@Generated("org.openrewrite.java.template.processor.RefasterTemplateProcessor")
+public class ParameterOrderRecipe extends Recipe {
+
+    /**
+     * Instantiates a new instance.
+     */
+    public ParameterOrderRecipe() {}
+
+    @Override
+    public String getDisplayName() {
+        //language=markdown
+        return "Refaster template `ParameterOrder`";
+    }
+
+    @Override
+    public String getDescription() {
+        //language=markdown
+        return "Recipe created for the following Refaster template:\n```java\npublic class ParameterOrder {\n    \n    @BeforeTemplate()\n    public int parameters(int b, int a) {\n        return a + b;\n    }\n    \n    @AfterTemplate()\n    public int output(int a, int b) {\n        return a + a + b;\n    }\n}\n```\n.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new AbstractRefasterJavaVisitor() {
+            final JavaTemplate parameters = JavaTemplate
+                    .builder("#{a:any(int)} + #{b:any(int)}")
+                    .build();
+            final JavaTemplate output = JavaTemplate
+                    .builder("#{a:any(int)} + #{a} + #{b:any(int)}")
+                    .build();
+
+            @Override
+            public J visitBinary(J.Binary elem, ExecutionContext ctx) {
+                JavaTemplate.Matcher matcher;
+                if ((matcher = parameters.matcher(getCursor())).find()) {
+                    return embed(
+                            output.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
+                            getCursor(),
+                            ctx,
+                            SHORTEN_NAMES
+                    );
+                }
+                return super.visitBinary(elem, ctx);
+            }
+
+        };
+    }
+}

--- a/src/test/resources/refaster/PreconditionsVerifier.java
+++ b/src/test/resources/refaster/PreconditionsVerifier.java
@@ -55,8 +55,8 @@ public class PreconditionsVerifier {
         }
 
         @AfterTemplate
-        Object after(Object actual) {
-            return Convert.quote(String.valueOf(actual));
+        Object after(Object value) {
+            return Convert.quote(String.valueOf(value));
         }
     }
 
@@ -72,8 +72,8 @@ public class PreconditionsVerifier {
         }
 
         @AfterTemplate
-        Object after(Object actual) {
-            return Convert.quote(String.valueOf(actual));
+        Object after(Object value) {
+            return Convert.quote(String.valueOf(value));
         }
     }
 

--- a/src/test/resources/refaster/PreconditionsVerifierRecipes.java
+++ b/src/test/resources/refaster/PreconditionsVerifierRecipes.java
@@ -154,7 +154,7 @@ public class PreconditionsVerifierRecipes extends Recipe {
 
         @Override
         public String getDescription() {
-            return "Recipe created for the following Refaster template:\n```java\npublic static class UsesTypeWhenBeforeTemplateContainsPrimitiveOrStringAndTypeInSomeBeforeBody {\n    \n    @BeforeTemplate()\n    String before(String value) {\n        return Convert.quote(value);\n    }\n    \n    @BeforeTemplate()\n    String before(int value) {\n        return String.valueOf(value);\n    }\n    \n    @AfterTemplate()\n    Object after(Object actual) {\n        return Convert.quote(String.valueOf(actual));\n    }\n}\n```\n.";
+            return "Recipe created for the following Refaster template:\n```java\npublic static class UsesTypeWhenBeforeTemplateContainsPrimitiveOrStringAndTypeInSomeBeforeBody {\n    \n    @BeforeTemplate()\n    String before(String value) {\n        return Convert.quote(value);\n    }\n    \n    @BeforeTemplate()\n    String before(int value) {\n        return String.valueOf(value);\n    }\n    \n    @AfterTemplate()\n    Object after(Object value) {\n        return Convert.quote(String.valueOf(value));\n    }\n}\n```\n.";
         }
 
         @Override
@@ -168,7 +168,7 @@ public class PreconditionsVerifierRecipes extends Recipe {
                         .builder("String.valueOf(#{value:any(int)})")
                         .build();
                 final JavaTemplate after = JavaTemplate
-                        .builder("com.sun.tools.javac.util.Convert.quote(String.valueOf(#{actual:any(java.lang.Object)}))")
+                        .builder("com.sun.tools.javac.util.Convert.quote(String.valueOf(#{value:any(java.lang.Object)}))")
                         .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
                         .build();
 
@@ -228,7 +228,7 @@ public class PreconditionsVerifierRecipes extends Recipe {
 
         @Override
         public String getDescription() {
-            return "Recipe created for the following Refaster template:\n```java\npublic static class UsesTypeWhenBeforeTemplateContainsPrimitiveOrStringAndTypeInAllBeforeBody {\n    \n    @BeforeTemplate()\n    String before(String value) {\n        return Convert.quote(value);\n    }\n    \n    @BeforeTemplate()\n    String before(int value) {\n        return Convert.quote(String.valueOf(value));\n    }\n    \n    @AfterTemplate()\n    Object after(Object actual) {\n        return Convert.quote(String.valueOf(actual));\n    }\n}\n```\n.";
+            return "Recipe created for the following Refaster template:\n```java\npublic static class UsesTypeWhenBeforeTemplateContainsPrimitiveOrStringAndTypeInAllBeforeBody {\n    \n    @BeforeTemplate()\n    String before(String value) {\n        return Convert.quote(value);\n    }\n    \n    @BeforeTemplate()\n    String before(int value) {\n        return Convert.quote(String.valueOf(value));\n    }\n    \n    @AfterTemplate()\n    Object after(Object value) {\n        return Convert.quote(String.valueOf(value));\n    }\n}\n```\n.";
         }
 
         @Override
@@ -243,7 +243,7 @@ public class PreconditionsVerifierRecipes extends Recipe {
                         .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
                         .build();
                 final JavaTemplate after = JavaTemplate
-                        .builder("com.sun.tools.javac.util.Convert.quote(String.valueOf(#{actual:any(java.lang.Object)}))")
+                        .builder("com.sun.tools.javac.util.Convert.quote(String.valueOf(#{value:any(java.lang.Object)}))")
                         .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
                         .build();
 


### PR DESCRIPTION
## What's changed?
- Fix issue #126.

Use the argument name to match parameters in matcher.

## What's your motivation?
Current implementation is a bit indeterministic.  It relies in the parameters to be in the same order as expressed in the body to work reliable. With this merge, a change in the order of the parameters won't affect the replacements.

## Anything in particular you'd like reviewers to focus on?
This might break current recipes.  See fixes in unrelated tests.
Should we do a validation for correctness? Checking that all the parameter names in @AfterTemplate are found in all @BeforeTemplate https://github.com/openrewrite/rewrite-templating/pull/108#issuecomment-2310842563

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
