### PR TITLE
Refaster.anyOf should visitBinary where applicable

### DIFF
--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -368,8 +368,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
             // Determine which visitMethods we should generate
             Map<String, Map<String, TemplateDescriptor>> templatesByLstType = new TreeMap<>();
             for (Map.Entry<String, TemplateDescriptor> entry : beforeTemplates.entrySet()) {
-                Set<Class<? extends JCTree>> types = entry.getValue().getTypes();
-                for (Class<? extends JCTree> type : types) {
+                for (Class<? extends JCTree> type : entry.getValue().getTypes()) {
                     for (String lstType : LST_TYPE_MAP.get(type)) {
                         templatesByLstType.computeIfAbsent(lstType, k -> new TreeMap<>())
                                 .put(entry.getKey(), entry.getValue());

--- a/src/test/resources/refaster/AnnotatedUnusedArgumentRecipe.java
+++ b/src/test/resources/refaster/AnnotatedUnusedArgumentRecipe.java
@@ -75,7 +75,7 @@ public class AnnotatedUnusedArgumentRecipe extends Recipe {
             @Override
             public J visitExpression(Expression elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
-                if ((matcher = before2.matcher(getCursor())).find()) {
+                if ((matcher = before1.matcher(getCursor())).find()) {
                     return embed(
                             after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                             getCursor(),
@@ -83,7 +83,7 @@ public class AnnotatedUnusedArgumentRecipe extends Recipe {
                             SHORTEN_NAMES
                     );
                 }
-                if ((matcher = before1.matcher(getCursor())).find()) {
+                if ((matcher = before2.matcher(getCursor())).find()) {
                     return embed(
                             after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                             getCursor(),

--- a/src/test/resources/refaster/MatchOrderRecipe.java
+++ b/src/test/resources/refaster/MatchOrderRecipe.java
@@ -75,11 +75,11 @@ public class MatchOrderRecipe extends Recipe {
             @Override
             public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
-                if ((matcher = before2.matcher(getCursor())).find()) {
-                    if (new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(0))) {
+                if ((matcher = before1.matcher(getCursor())).find()) {
+                    if (!new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(1))) {
                         return super.visitMethodInvocation(elem, ctx);
                     }
-                    if (!new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(1))) {
+                    if (new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(0))) {
                         return super.visitMethodInvocation(elem, ctx);
                     }
                     return embed(
@@ -89,11 +89,11 @@ public class MatchOrderRecipe extends Recipe {
                             SHORTEN_NAMES, SIMPLIFY_BOOLEANS
                     );
                 }
-                if ((matcher = before1.matcher(getCursor())).find()) {
-                    if (!new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(1))) {
+                if ((matcher = before2.matcher(getCursor())).find()) {
+                    if (new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(0))) {
                         return super.visitMethodInvocation(elem, ctx);
                     }
-                    if (new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(0))) {
+                    if (!new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(1))) {
                         return super.visitMethodInvocation(elem, ctx);
                     }
                     return embed(

--- a/src/test/resources/refaster/ParametersRecipes.java
+++ b/src/test/resources/refaster/ParametersRecipes.java
@@ -47,11 +47,13 @@ public class ParametersRecipes extends Recipe {
 
     @Override
     public String getDisplayName() {
+        //language=markdown
         return "`Parameters` Refaster recipes";
     }
 
     @Override
     public String getDescription() {
+        //language=markdown
         return "Refaster template recipes for `foo.Parameters`.";
     }
 
@@ -78,11 +80,13 @@ public class ParametersRecipes extends Recipe {
 
         @Override
         public String getDisplayName() {
+            //language=markdown
             return "Refaster template `Parameters.Reuse`";
         }
 
         @Override
         public String getDescription() {
+            //language=markdown
             return "Recipe created for the following Refaster template:\n```java\npublic class Reuse {\n    \n    @BeforeTemplate()\n    boolean before(String s) {\n        return s == s;\n    }\n    \n    @AfterTemplate()\n    boolean after(String s) {\n        return s.equals(s);\n    }\n}\n```\n.";
         }
 
@@ -129,11 +133,13 @@ public class ParametersRecipes extends Recipe {
 
         @Override
         public String getDisplayName() {
+            //language=markdown
             return "Refaster template `Parameters.Order`";
         }
 
         @Override
         public String getDescription() {
+            //language=markdown
             return "Recipe created for the following Refaster template:\n```java\npublic class Order {\n    \n    @BeforeTemplate()\n    boolean before1(int a, int b) {\n        return a == b;\n    }\n    \n    @BeforeTemplate()\n    boolean before2(int a, int b) {\n        return b == a;\n    }\n    \n    @AfterTemplate()\n    boolean after(int a, int b) {\n        return a == b;\n    }\n}\n```\n.";
         }
 
@@ -153,17 +159,17 @@ public class ParametersRecipes extends Recipe {
                 @Override
                 public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before2.matcher(getCursor())).find()) {
+                    if ((matcher = before1.matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(1), matcher.parameter(0)),
+                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
                         );
                     }
-                    if ((matcher = before1.matcher(getCursor())).find()) {
+                    if ((matcher = before2.matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
+                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(1), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS

--- a/src/test/resources/refaster/RefasterAnyOfRecipes.java
+++ b/src/test/resources/refaster/RefasterAnyOfRecipes.java
@@ -47,11 +47,13 @@ public class RefasterAnyOfRecipes extends Recipe {
 
     @Override
     public String getDisplayName() {
+        //language=markdown
         return "`RefasterAnyOf` Refaster recipes";
     }
 
     @Override
     public String getDescription() {
+        //language=markdown
         return "Refaster template recipes for `foo.RefasterAnyOf`.";
     }
 
@@ -79,11 +81,13 @@ public class RefasterAnyOfRecipes extends Recipe {
 
         @Override
         public String getDisplayName() {
+            //language=markdown
             return "Refaster template `RefasterAnyOf.StringIsEmpty`";
         }
 
         @Override
         public String getDescription() {
+            //language=markdown
             return "Recipe created for the following Refaster template:\n```java\npublic static class StringIsEmpty {\n    \n    @BeforeTemplate()\n    boolean before(String s) {\n        return Refaster.anyOf(s.length() < 1, s.length() == 0);\n    }\n    \n    @AfterTemplate()\n    boolean after(String s) {\n        return s.isEmpty();\n    }\n}\n```\n.";
         }
 
@@ -145,11 +149,13 @@ public class RefasterAnyOfRecipes extends Recipe {
 
         @Override
         public String getDisplayName() {
+            //language=markdown
             return "Refaster template `RefasterAnyOf.EmptyList`";
         }
 
         @Override
         public String getDescription() {
+            //language=markdown
             return "Recipe created for the following Refaster template:\n```java\npublic static class EmptyList {\n    \n    @BeforeTemplate()\n    List before() {\n        return Refaster.anyOf(new LinkedList(), java.util.Collections.emptyList());\n    }\n    \n    @AfterTemplate()\n    List after() {\n        return new java.util.ArrayList();\n    }\n}\n```\n.";
         }
 
@@ -167,7 +173,7 @@ public class RefasterAnyOfRecipes extends Recipe {
                         .build();
 
                 @Override
-                public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
+                public J visitNewClass(J.NewClass elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before$0.matcher(getCursor())).find()) {
                         maybeRemoveImport("java.util.LinkedList");
@@ -187,7 +193,7 @@ public class RefasterAnyOfRecipes extends Recipe {
                                 SHORTEN_NAMES
                         );
                     }
-                    return super.visitMethodInvocation(elem, ctx);
+                    return super.visitNewClass(elem, ctx);
                 }
 
             };
@@ -225,11 +231,13 @@ public class RefasterAnyOfRecipes extends Recipe {
 
         @Override
         public String getDisplayName() {
+            //language=markdown
             return "Refaster template `RefasterAnyOf.NewStringFromCharArraySubSequence`";
         }
 
         @Override
         public String getDescription() {
+            //language=markdown
             return "Recipe created for the following Refaster template:\n```java\npublic static class NewStringFromCharArraySubSequence {\n    \n    @BeforeTemplate()\n    String before(char[] data, int offset, int count) {\n        return Refaster.anyOf(String.valueOf(data, offset, count), String.copyValueOf(data, offset, count));\n    }\n    \n    @AfterTemplate()\n    String after(char[] data, int offset, int count) {\n        return new String(data, offset, count);\n    }\n}\n```\n.";
         }
 

--- a/src/test/resources/refaster/RefasterAnyOfRecipes.java
+++ b/src/test/resources/refaster/RefasterAnyOfRecipes.java
@@ -101,7 +101,7 @@ public class RefasterAnyOfRecipes extends Recipe {
                         .build();
 
                 @Override
-                public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
+                public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before$0.matcher(getCursor())).find()) {
                         return embed(
@@ -119,7 +119,7 @@ public class RefasterAnyOfRecipes extends Recipe {
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
                         );
                     }
-                    return super.visitMethodInvocation(elem, ctx);
+                    return super.visitBinary(elem, ctx);
                 }
 
             };

--- a/src/test/resources/refaster/RefasterAnyOfRecipes.java
+++ b/src/test/resources/refaster/RefasterAnyOfRecipes.java
@@ -173,6 +173,30 @@ public class RefasterAnyOfRecipes extends Recipe {
                         .build();
 
                 @Override
+                public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
+                    JavaTemplate.Matcher matcher;
+                    if ((matcher = before$0.matcher(getCursor())).find()) {
+                        maybeRemoveImport("java.util.LinkedList");
+                        return embed(
+                                after.apply(getCursor(), elem.getCoordinates().replace()),
+                                getCursor(),
+                                ctx,
+                                SHORTEN_NAMES
+                        );
+                    }
+                    if ((matcher = before$1.matcher(getCursor())).find()) {
+                        maybeRemoveImport("java.util.Collections");
+                        return embed(
+                                after.apply(getCursor(), elem.getCoordinates().replace()),
+                                getCursor(),
+                                ctx,
+                                SHORTEN_NAMES
+                        );
+                    }
+                    return super.visitMethodInvocation(elem, ctx);
+                }
+
+                @Override
                 public J visitNewClass(J.NewClass elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = before$0.matcher(getCursor())).find()) {


### PR DESCRIPTION
Previously we always used `visitMethodInvocation` when `Refaster.anyOf` was used; that's not right, and leads to various mismatches. The approach seen here is better in that we use the types of the arguments to `Refaster.anyOf`, to handle cases as seen here:
https://github.com/PicnicSupermarket/error-prone-support/blob/bb01447760dd97fc5977b498b9d5b202f0bbb26f/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java#L48-L56

Notice how that now ought to generate `visitBinary` as well as `visitMethodInvocation`.
```
    boolean before(Collection<T> collection) {
      return Refaster.anyOf(
          collection.size() == 0,
          collection.size() <= 0,
          collection.size() < 1,
          Iterables.isEmpty(collection),
          collection.stream().findAny().isEmpty(),
          collection.stream().findFirst().isEmpty());
    }
```