### PR TITLE
Fix parameter order when using Refaster.anyOf

### DIFF
--- a/src/main/java/org/openrewrite/java/template/internal/TemplateCode.java
+++ b/src/main/java/org/openrewrite/java/template/internal/TemplateCode.java
@@ -115,17 +115,12 @@ public class TemplateCode {
                     if (seenParameters.add(param.get())) {
                         Type type = param.get().sym.type;
                         String typeString;
-                        if (type instanceof Type.ArrayType) {
-                            Type elemtype = ((Type.ArrayType) type).elemtype;
-                            print(":anyArray(" + templateTypeString(elemtype) + ")");
+                        if (isPrimitive) {
+                            typeString = getUnboxedPrimitive(type.toString());
                         } else {
-                            if (isPrimitive) {
-                                typeString = getUnboxedPrimitive(type.toString());
-                            } else {
-                                typeString = templateTypeString(type);
-                            }
-                            print(":any(" + typeString + ")");
+                            typeString = templateTypeString(type);
                         }
+                        print(":any(" + typeString + ")");
                     }
                     print("}");
                 } else if (sym != null) {

--- a/src/test/resources/refaster/ArraysRecipe.java
+++ b/src/test/resources/refaster/ArraysRecipe.java
@@ -62,10 +62,10 @@ public class ArraysRecipe extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
             final JavaTemplate before = JavaTemplate
-                    .builder("String.join(\", \", #{strings:anyArray(java.lang.String)})")
+                    .builder("String.join(\", \", #{strings:any(java.lang.String[])})")
                     .build();
             final JavaTemplate after = JavaTemplate
-                    .builder("String.join(\":\", #{strings:anyArray(java.lang.String)})")
+                    .builder("String.join(\":\", #{strings:any(java.lang.String[])})")
                     .build();
 
             @Override

--- a/src/test/resources/refaster/ParametersRecipes.java
+++ b/src/test/resources/refaster/ParametersRecipes.java
@@ -149,10 +149,10 @@ public class ParametersRecipes extends Recipe {
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             return new AbstractRefasterJavaVisitor() {
                 final JavaTemplate before = JavaTemplate
-                        .builder("#{s:anyArray(java.lang.String)} == #{s}")
+                        .builder("#{s:any(java.lang.String[])} == #{s}")
                         .build();
                 final JavaTemplate after = JavaTemplate
-                        .builder("#{s:anyArray(java.lang.String)}.equals(#{s})")
+                        .builder("#{s:any(java.lang.String[])}.equals(#{s})")
                         .build();
 
                 @Override

--- a/src/test/resources/refaster/RefasterAnyOf.java
+++ b/src/test/resources/refaster/RefasterAnyOf.java
@@ -19,6 +19,8 @@ import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 
+import java.time.Duration;
+import java.time.OffsetDateTime;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -56,6 +58,20 @@ public class RefasterAnyOf {
         @AfterTemplate
         String after(char[] data, int offset, int count) {
             return new String(data, offset, count);
+        }
+    }
+
+    public static class ChangeOrderParameters {
+        @BeforeTemplate
+        Duration before(OffsetDateTime a, OffsetDateTime b) {
+            return Refaster.anyOf(
+                    Duration.between(a.toInstant(), b.toInstant()),
+                    Duration.ofSeconds(b.toEpochSecond() - a.toEpochSecond()));
+        }
+
+        @AfterTemplate
+        Duration after(OffsetDateTime a, OffsetDateTime b) {
+            return Duration.between(a, b);
         }
     }
 }

--- a/src/test/resources/refaster/RefasterAnyOfRecipes.java
+++ b/src/test/resources/refaster/RefasterAnyOfRecipes.java
@@ -62,7 +62,8 @@ public class RefasterAnyOfRecipes extends Recipe {
         return Arrays.asList(
                 new StringIsEmptyRecipe(),
                 new EmptyListRecipe(),
-                new NewStringFromCharArraySubSequenceRecipe()
+                new NewStringFromCharArraySubSequenceRecipe(),
+                new ChangeOrderParametersRecipe()
         );
     }
 
@@ -269,13 +270,13 @@ public class RefasterAnyOfRecipes extends Recipe {
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
                 final JavaTemplate before$0 = JavaTemplate
-                        .builder("String.valueOf(#{data:anyArray(char)}, #{offset:any(int)}, #{count:any(int)})")
+                        .builder("String.valueOf(#{data:any(char[])}, #{offset:any(int)}, #{count:any(int)})")
                         .build();
                 final JavaTemplate before$1 = JavaTemplate
-                        .builder("String.copyValueOf(#{data:anyArray(char)}, #{offset:any(int)}, #{count:any(int)})")
+                        .builder("String.copyValueOf(#{data:any(char[])}, #{offset:any(int)}, #{count:any(int)})")
                         .build();
                 final JavaTemplate after = JavaTemplate
-                        .builder("new String(#{data:anyArray(char)}, #{offset:any(int)}, #{count:any(int)})")
+                        .builder("new String(#{data:any(char[])}, #{offset:any(int)}, #{count:any(int)})")
                         .build();
 
                 @Override
@@ -305,6 +306,87 @@ public class RefasterAnyOfRecipes extends Recipe {
                     Preconditions.or(
                             new UsesMethod<>("java.lang.String copyValueOf(..)", true),
                             new UsesMethod<>("java.lang.String valueOf(..)", true)
+                    ),
+                    javaVisitor
+            );
+        }
+    }
+
+    /**
+     * OpenRewrite recipe created for Refaster template {@code RefasterAnyOf.ChangeOrderParameters}.
+     */
+    @SuppressWarnings("all")
+    @NullMarked
+    @Generated("org.openrewrite.java.template.processor.RefasterTemplateProcessor")
+    public static class ChangeOrderParametersRecipe extends Recipe {
+
+        /**
+         * Instantiates a new instance.
+         */
+        public ChangeOrderParametersRecipe() {}
+
+        @Override
+        public String getDisplayName() {
+            //language=markdown
+            return "Refaster template `RefasterAnyOf.ChangeOrderParameters`";
+        }
+
+        @Override
+        public String getDescription() {
+            //language=markdown
+            return "Recipe created for the following Refaster template:\n```java\npublic static class ChangeOrderParameters {\n    \n    @BeforeTemplate()\n    Duration before(OffsetDateTime a, OffsetDateTime b) {\n        return Refaster.anyOf(Duration.between(a.toInstant(), b.toInstant()), Duration.ofSeconds(b.toEpochSecond() - a.toEpochSecond()));\n    }\n    \n    @AfterTemplate()\n    Duration after(OffsetDateTime a, OffsetDateTime b) {\n        return Duration.between(a, b);\n    }\n}\n```\n.";
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor() {
+            JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
+                final JavaTemplate before$0 = JavaTemplate
+                        .builder("java.time.Duration.between(#{a:any(java.time.OffsetDateTime)}.toInstant(), #{b:any(java.time.OffsetDateTime)}.toInstant())")
+                        .build();
+                final JavaTemplate before$1 = JavaTemplate
+                        .builder("java.time.Duration.ofSeconds(#{b:any(java.time.OffsetDateTime)}.toEpochSecond() - #{a:any(java.time.OffsetDateTime)}.toEpochSecond())")
+                        .build();
+                final JavaTemplate after = JavaTemplate
+                        .builder("java.time.Duration.between(#{a:any(java.time.OffsetDateTime)}, #{b:any(java.time.OffsetDateTime)})")
+                        .build();
+
+                @Override
+                public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
+                    JavaTemplate.Matcher matcher;
+                    if ((matcher = before$0.matcher(getCursor())).find()) {
+                        return embed(
+                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
+                                getCursor(),
+                                ctx,
+                                SHORTEN_NAMES
+                        );
+                    }
+                    if ((matcher = before$1.matcher(getCursor())).find()) {
+                        return embed(
+                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(1), matcher.parameter(0)),
+                                getCursor(),
+                                ctx,
+                                SHORTEN_NAMES
+                        );
+                    }
+                    return super.visitMethodInvocation(elem, ctx);
+                }
+
+            };
+            return Preconditions.check(
+                    Preconditions.and(
+                            new UsesType<>("java.time.Duration", true),
+                            new UsesType<>("java.time.OffsetDateTime", true),
+                            Preconditions.or(
+                                    Preconditions.and(
+                                            new UsesMethod<>("java.time.Duration between(..)", true),
+                                            new UsesMethod<>("java.time.OffsetDateTime toInstant(..)", true)
+                                    ),
+                                    Preconditions.and(
+                                            new UsesMethod<>("java.time.Duration ofSeconds(..)", true),
+                                            new UsesMethod<>("java.time.OffsetDateTime toEpochSecond(..)", true)
+                                    )
+                            )
                     ),
                     javaVisitor
             );


### PR DESCRIPTION
## What's changed?
Fix parameter order when using Refaster.anyOf
Deprecate anyArray()

## Anyone you would like to review specifically?
@knutwannheden 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
