### PR TITLE
Fix compiler error on JDK9+

### DIFF
--- a/src/main/java/org/openrewrite/java/template/internal/JavacResolution.java
+++ b/src/main/java/org/openrewrite/java/template/internal/JavacResolution.java
@@ -254,7 +254,7 @@ public class JavacResolution {
             }
         }
 
-        public static Map<?, ?> enableTempCache(Context context) {
+        public static @Nullable Map<?, ?> enableTempCache(Context context) {
             if (ARGUMENT_TYPE_CACHE == null) {
                 return null;
             }

--- a/src/main/java/org/openrewrite/java/template/internal/JavacResolution.java
+++ b/src/main/java/org/openrewrite/java/template/internal/JavacResolution.java
@@ -34,6 +34,8 @@ import org.jspecify.annotations.Nullable;
 
 import javax.tools.JavaFileObject;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
@@ -41,11 +43,13 @@ import java.util.concurrent.atomic.AtomicReference;
 
 @SuppressWarnings("ConstantConditions")
 public class JavacResolution {
+    private final Context context;
     private final Attr attr;
     private final TreeMirrorMaker mirrorMaker;
     private final Log log;
 
     public JavacResolution(Context context) {
+        this.context = context;
         this.attr = Attr.instance(context);
         this.mirrorMaker = new TreeMirrorMaker(new JavacTreeMaker(TreeMaker.instance(context)));
         this.log = Log.instance(context);
@@ -142,14 +146,22 @@ public class JavacResolution {
                 // This addresses issue #1553 which involves JDK9; if it doesn't exist, we probably don't need to set it.
             }
         }
-        if (tree instanceof JCBlock) {
-            attr.attribStat(tree, env);
-        } else if (tree instanceof JCMethodDecl) {
-            attr.attribStat(((JCMethodDecl) tree).body, env);
-        } else if (tree instanceof JCVariableDecl) {
-            attr.attribStat(tree, env);
-        } else {
-            throw new IllegalStateException("Called with something that isn't a block, method decl, or variable decl");
+
+        Map<?, ?> cache = null;
+        try {
+            cache = ArgumentAttrReflect.enableTempCache(context);
+
+            if (tree instanceof JCBlock) {
+                attr.attribStat(tree, env);
+            } else if (tree instanceof JCMethodDecl) {
+                attr.attribStat(((JCMethodDecl) tree).body, env);
+            } else if (tree instanceof JCVariableDecl) {
+                attr.attribStat(tree, env);
+            } else {
+                throw new IllegalStateException("Called with something that isn't a block, method decl, or variable decl");
+            }
+        } finally {
+            ArgumentAttrReflect.restoreCache(cache, context);
         }
     }
 
@@ -223,6 +235,51 @@ public class JavacResolution {
 
         @Override
         public void visitTree(JCTree that) {
+        }
+    }
+
+    /**
+     * ArgumentAttr was added in Java 9 and caches some method arguments. Lombok should cleanup its changes after resolution.
+     */
+    private static class ArgumentAttrReflect {
+        private static Method INSTANCE;
+        private static Field ARGUMENT_TYPE_CACHE;
+
+        static {
+            try {
+                Class<?> argumentAttr = Class.forName("com.sun.tools.javac.comp.ArgumentAttr");
+                INSTANCE = argumentAttr.getMethod("instance", Context.class);
+                ARGUMENT_TYPE_CACHE = Permit.getField(argumentAttr, "argumentTypeCache");
+            } catch (Exception ignore) {
+            }
+        }
+
+        public static Map<?, ?> enableTempCache(Context context) {
+            if (ARGUMENT_TYPE_CACHE == null) {
+                return null;
+            }
+
+            try {
+                Object argumentAttr = INSTANCE.invoke(null, context);
+                Map<?, ?> cache = (Map<?, ?>) Permit.get(ARGUMENT_TYPE_CACHE, argumentAttr);
+                Permit.set(ARGUMENT_TYPE_CACHE, argumentAttr, new LinkedHashMap<Object, Object>(cache));
+                return cache;
+            } catch (Exception ignore) {
+            }
+
+            return null;
+        }
+
+        public static void restoreCache(Map<?, ?> cache, Context context) {
+            if (ARGUMENT_TYPE_CACHE == null) {
+                return;
+            }
+
+            try {
+                Object argumentAttr = INSTANCE.invoke(null, context);
+                Permit.set(ARGUMENT_TYPE_CACHE, argumentAttr, cache);
+            } catch (Exception ignore) {
+            }
         }
     }
 }


### PR DESCRIPTION
## What's changed?
Fix rewrite-templating from breaking the java compiler JDK9+

## What's your motivation?
After enable support for generics the compilation starts failing.

## Anything in particular you'd like reviewers to focus on?
The code is mostly extracted from [lombok](https://github.com/projectlombok/lombok/blob/v1.18.36/src/core/lombok/javac/JavacResolution.java#L262). Lombok seems to use some stub for [`ArgumentAttr`](https://github.com/projectlombok/lombok/blob/master/src/stubs/com/sun/tools/javac/comp/ArgumentAttr.java), I just loaded via reflection.

## Any additional context
It seems after running the type resolution, the compiler caches some type information. Later, on the real compilation, it uses this cache and the types mismatch.

This is the minimal template that reproduces the error.
```
package com.yourorg;

import com.google.errorprone.refaster.annotation.BeforeTemplate;
import java.util.Optional;

public class Foo<T> {

    @BeforeTemplate
    public T before(Optional<T> a, Optional<T> b) {
        return a.orElseGet(() -> b.get());
    }
}
```

```
[INFO] --- compiler:3.13.0:compile (default-compile) @ rewrite-recipe-starter ---
[INFO] Recompiling the module because of changed source code.
[INFO] Compiling 11 source files with javac [debug target 11] to target\classes
[INFO] Some messages have been simplified; recompile with -Xdiags:verbose to get full output
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /C:/Users/fran/Projects/rewrite-recipe-starter/src/main/java/com/yourorg/Foo.java:[12,39] incompatible types: bad return type in lambda expression
    T cannot be converted to T
[INFO] 1 error
```

Compilation works with JDK 8 but breaks after that

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
