### PR TITLE
Fix JDK24 compilation error

### DIFF
--- a/src/main/java/org/openrewrite/java/template/internal/Javac.java
+++ b/src/main/java/org/openrewrite/java/template/internal/Javac.java
@@ -24,6 +24,7 @@ package org.openrewrite.java.template.internal;
 import org.openrewrite.java.template.internal.JavacTreeMaker.TypeTag;
 
 import static org.openrewrite.java.template.internal.JavacTreeMaker.TypeTag.typeTag;
+import static org.openrewrite.java.template.internal.JavacTreeMaker.TypeTag.typeTagPermissive;
 
 public final class Javac {
     private Javac() {
@@ -33,8 +34,8 @@ public final class Javac {
     public static final TypeTag CTC_VOID = typeTag("VOID");
     public static final TypeTag CTC_NONE = typeTag("NONE");
     public static final TypeTag CTC_ERROR = typeTag("ERROR");
-    public static final TypeTag CTC_UNKNOWN = typeTag("UNKNOWN");
     public static final TypeTag CTC_UNDETVAR = typeTag("UNDETVAR");
+    public static final TypeTag CTC_UNKNOWN = typeTagPermissive("UNKNOWN"); // UNKNOWN has been removed in JDK24, hence, we need to look it up permissively (just make it `null` if it does not exist).
 
     static RuntimeException sneakyThrow(Throwable t) {
         if (t == null) {

--- a/src/main/java/org/openrewrite/java/template/internal/JavacTreeMaker.java
+++ b/src/main/java/org/openrewrite/java/template/internal/JavacTreeMaker.java
@@ -191,7 +191,7 @@ public class JavacTreeMaker {
             return new TypeTag(getFieldCached(TYPE_TAG_CACHE, "com.sun.tools.javac.code.TypeTag", identifier));
         }
 
-        public static TypeTag typeTagPermissive(String identifier) {
+        public static @Nullable TypeTag typeTagPermissive(String identifier) {
             try {
                 return typeTag(identifier);
             } catch (Exception e) {

--- a/src/main/java/org/openrewrite/java/template/internal/JavacTreeMaker.java
+++ b/src/main/java/org/openrewrite/java/template/internal/JavacTreeMaker.java
@@ -190,6 +190,15 @@ public class JavacTreeMaker {
         public static TypeTag typeTag(String identifier) {
             return new TypeTag(getFieldCached(TYPE_TAG_CACHE, "com.sun.tools.javac.code.TypeTag", identifier));
         }
+
+        public static TypeTag typeTagPermissive(String identifier) {
+            try {
+                return typeTag(identifier);
+            } catch (Exception e) {
+                if (e instanceof NoSuchFieldException) return null;
+                throw Javac.sneakyThrow(e);
+            }
+        }
     }
 
 }

--- a/src/main/java/org/openrewrite/java/template/internal/TreeMirrorMaker.java
+++ b/src/main/java/org/openrewrite/java/template/internal/TreeMirrorMaker.java
@@ -117,7 +117,7 @@ public class TreeMirrorMaker extends TreeCopier<Void> {
             boolean wipeSymAndType = copy.type.isErroneous();
             if (!wipeSymAndType) {
                 TypeTag typeTag = TypeTag.typeTag(copy.type);
-                wipeSymAndType = CTC_NONE.equals(typeTag) || CTC_ERROR.equals(typeTag) || CTC_UNKNOWN.equals(typeTag) || CTC_UNDETVAR.equals(typeTag);
+                wipeSymAndType = typeTag.equals(CTC_NONE) || typeTag.equals(CTC_ERROR) || typeTag.equals(CTC_UNKNOWN) || typeTag.equals(CTC_UNDETVAR);
             }
 
             if (wipeSymAndType) {


### PR DESCRIPTION
## What's changed?
Sync with [lombok code](https://github.com/projectlombok/lombok/blob/master/src/utils/lombok/javac/Javac.java#L187)

## What's your motivation
OpenJDK has remove the `TypeTag.UNKNOWN` constant in JDK24.
Any attempt to use `Javac` class will result in the following exception.
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.13.0:compile (default-compile) on project rewrite-recipe-starter: Fatal error compiling: java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTag :: UNKNOWN -> [Help 1]
```

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
