### PR TITLE
Remove `ADD_PARENS` embedding option

### DIFF
--- a/src/main/java/org/openrewrite/java/template/internal/AbstractRefasterJavaVisitor.java
+++ b/src/main/java/org/openrewrite/java/template/internal/AbstractRefasterJavaVisitor.java
@@ -38,9 +38,6 @@ public abstract class AbstractRefasterJavaVisitor extends JavaVisitor<ExecutionC
         if (optionsSet.contains(EmbeddingOption.REMOVE_PARENS) && !getAfterVisit().contains(visitor = new UnnecessaryParenthesesVisitor<>())) {
             doAfterVisit(visitor);
         }
-        if (optionsSet.contains(EmbeddingOption.ADD_PARENS)) {
-            j = new MinimumViableParentheses().visitNonNull(j, ctx, cursor.getParentOrThrow());
-        }
         if (optionsSet.contains(EmbeddingOption.SHORTEN_NAMES)) {
             doAfterVisit(service(ImportService.class).shortenFullyQualifiedTypeReferencesIn(j));
         }
@@ -51,6 +48,8 @@ public abstract class AbstractRefasterJavaVisitor extends JavaVisitor<ExecutionC
     }
 
     public enum EmbeddingOption {
-        SHORTEN_NAMES, SIMPLIFY_BOOLEANS, REMOVE_PARENS, ADD_PARENS
+        SHORTEN_NAMES,
+        SIMPLIFY_BOOLEANS,
+        REMOVE_PARENS,
     }
 }


### PR DESCRIPTION
Now that `JavaTemplate` automatically handles this, the embedding option is no longer required.
