### PR TITLE
Changed processor to inline `before` and `after` templates

### DIFF
--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -238,7 +238,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                 recipe.append("    @Override\n");
                 recipe.append("    public TreeVisitor<?, ExecutionContext> getVisitor() {\n");
 
-                String javaVisitor = newAbstractRefasterJavaVisitor(beforeTemplates, after, descriptor);
+                String javaVisitor = newAbstractRefasterJavaVisitor(beforeTemplates, descriptor);
 
                 Precondition preconditions = generatePreconditions(descriptor.beforeTemplates, 16);
                 if (preconditions == null) {
@@ -345,7 +345,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
             }
         }
 
-        private String newAbstractRefasterJavaVisitor(Map<String, TemplateDescriptor> beforeTemplates, String after, RuleDescriptor descriptor) {
+        private String newAbstractRefasterJavaVisitor(Map<String, TemplateDescriptor> beforeTemplates, RuleDescriptor descriptor) {
             StringBuilder visitor = new StringBuilder();
             visitor.append("new AbstractRefasterJavaVisitor() {\n");
             // Determine which visitMethods we should generate
@@ -357,12 +357,12 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                 }
             }
             templatesByLstType.forEach((lstType, typeBeforeTemplates) ->
-                    visitor.append(generateVisitMethod(typeBeforeTemplates, after, descriptor, lstType)));
+                    visitor.append(generateVisitMethod(typeBeforeTemplates, descriptor, lstType)));
             visitor.append("        }");
             return visitor.toString();
         }
 
-        private String generateVisitMethod(Map<String, TemplateDescriptor> beforeTemplates, String after, RuleDescriptor descriptor, String lstType) {
+        private String generateVisitMethod(Map<String, TemplateDescriptor> beforeTemplates, RuleDescriptor descriptor, String lstType) {
             StringBuilder visitMethod = new StringBuilder();
             String methodSuffix = lstType.startsWith("J.") ? lstType.substring(2) : lstType;
             visitMethod.append("            @Override\n");

--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -213,8 +213,6 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                     }
                     beforeTemplates.put(name, templ);
                 }
-                String after = descriptor.afterTemplate == null ? null :
-                        descriptor.afterTemplate.method.name.toString();
 
                 StringBuilder recipe = new StringBuilder();
                 Symbol.PackageSymbol pkg = classDecl.sym.packge();
@@ -240,7 +238,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
 
                 String javaVisitor = newAbstractRefasterJavaVisitor(beforeTemplates, descriptor);
 
-                Precondition preconditions = generatePreconditions(descriptor.beforeTemplates, 16);
+                Precondition preconditions = generatePreconditions(descriptor.beforeTemplates);
                 if (preconditions == null) {
                     recipe.append(String.format("        return %s;\n", javaVisitor));
                 } else {
@@ -627,7 +625,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
         }
 
         /* Generate the minimal precondition that would allow to match each before template individually. */
-        private @Nullable Precondition generatePreconditions(List<TemplateDescriptor> beforeTemplates, int indent) {
+        private @Nullable Precondition generatePreconditions(List<TemplateDescriptor> beforeTemplates) {
             Set<Set<Precondition>> preconditions = new HashSet<>();
             for (TemplateDescriptor beforeTemplate : beforeTemplates) {
                 int arity = beforeTemplate.getArity();

--- a/src/test/resources/refaster/AnnotatedUnusedArgumentRecipe.java
+++ b/src/test/resources/refaster/AnnotatedUnusedArgumentRecipe.java
@@ -62,30 +62,29 @@ public class AnnotatedUnusedArgumentRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new AbstractRefasterJavaVisitor() {
-            final JavaTemplate before1 = JavaTemplate
-                    .builder("#{a:any(int)}")
-                    .build();
-            final JavaTemplate before2 = JavaTemplate
-                    .builder("#{a:any(int)}")
-                    .build();
-            final JavaTemplate after = JavaTemplate
-                    .builder("#{a:any(int)}")
-                    .build();
 
             @Override
             public J visitExpression(Expression elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
-                if ((matcher = before1.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("#{a:any(int)}")
+                        .build().matcher(getCursor())).find()) {
                     return embed(
-                            after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                            JavaTemplate
+                                    .builder("#{a:any(int)}")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                             getCursor(),
                             ctx,
                             SHORTEN_NAMES
                     );
                 }
-                if ((matcher = before2.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("#{a:any(int)}")
+                        .build().matcher(getCursor())).find()) {
                     return embed(
-                            after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                            JavaTemplate
+                                    .builder("#{a:any(int)}")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                             getCursor(),
                             ctx,
                             SHORTEN_NAMES

--- a/src/test/resources/refaster/ArraysRecipe.java
+++ b/src/test/resources/refaster/ArraysRecipe.java
@@ -61,19 +61,17 @@ public class ArraysRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-            final JavaTemplate before = JavaTemplate
-                    .builder("String.join(\", \", #{strings:any(java.lang.String[])})")
-                    .build();
-            final JavaTemplate after = JavaTemplate
-                    .builder("String.join(\":\", #{strings:any(java.lang.String[])})")
-                    .build();
 
             @Override
             public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
-                if ((matcher = before.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("String.join(\", \", #{strings:any(java.lang.String[])})")
+                        .build().matcher(getCursor())).find()) {
                     return embed(
-                            after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                            JavaTemplate
+                                    .builder("String.join(\":\", #{strings:any(java.lang.String[])})")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                             getCursor(),
                             ctx,
                             SHORTEN_NAMES

--- a/src/test/resources/refaster/CharacterEscapeAnnotationRecipe.java
+++ b/src/test/resources/refaster/CharacterEscapeAnnotationRecipe.java
@@ -66,19 +66,17 @@ public class CharacterEscapeAnnotationRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new AbstractRefasterJavaVisitor() {
-            final JavaTemplate before = JavaTemplate
-                    .builder("\"The answer to life, the universe, and everything\"")
-                    .build();
-            final JavaTemplate after = JavaTemplate
-                    .builder("\"42\"")
-                    .build();
 
             @Override
             public J visitExpression(Expression elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
-                if ((matcher = before.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("\"The answer to life, the universe, and everything\"")
+                        .build().matcher(getCursor())).find()) {
                     return embed(
-                            after.apply(getCursor(), elem.getCoordinates().replace()),
+                            JavaTemplate
+                                    .builder("\"42\"")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace()),
                             getCursor(),
                             ctx,
                             SHORTEN_NAMES

--- a/src/test/resources/refaster/ComplexGenericsRecipe.java
+++ b/src/test/resources/refaster/ComplexGenericsRecipe.java
@@ -62,21 +62,19 @@ public class ComplexGenericsRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-            final JavaTemplate before = JavaTemplate
-                    .builder("#{stream:any(java.util.stream.Stream<S>)}.collect(#{collector:any(java.util.stream.Collector<S, ?, ? extends java.util.List<T>>)}).containsAll(#{list:any(java.util.List<U>)})")
-                    .genericTypes("S extends java.io.Serializable & java.lang.Comparable<? super S>", "T extends S", "U extends T")
-                    .build();
-            final JavaTemplate after = JavaTemplate
-                    .builder("#{stream:any(java.util.stream.Stream<S>)}.collect(#{collector:any(java.util.stream.Collector<S, ?, ? extends java.lang.Iterable<T>>)}).equals(#{list:any(java.util.List<U>)})")
-                    .genericTypes("S extends java.io.Serializable & java.lang.Comparable<? super S>", "T extends S", "U extends T")
-                    .build();
 
             @Override
             public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
-                if ((matcher = before.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("#{stream:any(java.util.stream.Stream<S>)}.collect(#{collector:any(java.util.stream.Collector<S, ?, ? extends java.util.List<T>>)}).containsAll(#{list:any(java.util.List<U>)})")
+                        .genericTypes("S extends java.io.Serializable & java.lang.Comparable<? super S>", "T extends S", "U extends T")
+                        .build().matcher(getCursor())).find()) {
                     return embed(
-                            after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
+                            JavaTemplate
+                                    .builder("#{stream:any(java.util.stream.Stream<S>)}.collect(#{collector:any(java.util.stream.Collector<S, ?, ? extends java.lang.Iterable<T>>)}).equals(#{list:any(java.util.List<U>)})")
+                                    .genericTypes("S extends java.io.Serializable & java.lang.Comparable<? super S>", "T extends S", "U extends T")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
                             getCursor(),
                             ctx,
                             SHORTEN_NAMES, SIMPLIFY_BOOLEANS

--- a/src/test/resources/refaster/EscapesRecipes.java
+++ b/src/test/resources/refaster/EscapesRecipes.java
@@ -89,22 +89,20 @@ public class EscapesRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("String.format(\"\\\"%s\\\"\", com.sun.tools.javac.util.Convert.quote(#{value:any(java.lang.String)}))")
-                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("com.sun.tools.javac.util.Constants.format(#{value:any(java.lang.String)})")
-                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("String.format(\"\\\"%s\\\"\", com.sun.tools.javac.util.Convert.quote(#{value:any(java.lang.String)}))")
+                            .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                            .build().matcher(getCursor())).find()) {
                         maybeRemoveImport("com.sun.tools.javac.util.Convert");
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("com.sun.tools.javac.util.Constants.format(#{value:any(java.lang.String)})")
+                                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
@@ -151,19 +149,17 @@ public class EscapesRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.split(\"[^\\\\S]+\")")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.split(\"\\\\s+\")")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.split(\"[^\\\\S]+\")")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String)}.split(\"\\\\s+\")")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES

--- a/src/test/resources/refaster/FindListAddRecipe.java
+++ b/src/test/resources/refaster/FindListAddRecipe.java
@@ -62,14 +62,13 @@ public class FindListAddRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-            final JavaTemplate before = JavaTemplate
-                    .builder("#{l:any(java.util.List<java.lang.String>)}.add(#{o:any(java.lang.String)})")
-                    .build();
 
             @Override
             public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
-                if ((matcher = before.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("#{l:any(java.util.List<java.lang.String>)}.add(#{o:any(java.lang.String)})")
+                        .build().matcher(getCursor())).find()) {
                     return SearchResult.found(elem);
                 }
                 return super.visitMethodInvocation(elem, ctx);

--- a/src/test/resources/refaster/GenericsRecipes.java
+++ b/src/test/resources/refaster/GenericsRecipes.java
@@ -95,19 +95,17 @@ public class GenericsRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{l:any(java.util.List<java.lang.String>)}.iterator().next()")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{l:any(java.util.List<java.lang.String>)}.get(0)")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{l:any(java.util.List<java.lang.String>)}.iterator().next()")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("#{l:any(java.util.List<java.lang.String>)}.get(0)")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
@@ -156,30 +154,20 @@ public class GenericsRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate emptyList = JavaTemplate
-                        .builder("java.util.Collections.emptyList()")
-                        .genericTypes("K", "T")
-                        .build();
-                final JavaTemplate emptyMap = JavaTemplate
-                        .builder("java.util.Collections.<K, T>emptyMap().values()")
-                        .genericTypes("K", "T")
-                        .build();
-                final JavaTemplate newList = JavaTemplate
-                        .builder("new java.util.ArrayList<>()")
-                        .genericTypes("K", "T")
-                        .build();
-                final JavaTemplate newMap = JavaTemplate
-                        .builder("new java.util.HashMap<>()")
-                        .genericTypes("K", "T")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = emptyList.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("java.util.Collections.emptyList()")
+                            .genericTypes("K", "T")
+                            .build().matcher(getCursor())).find()) {
                         return SearchResult.found(elem);
                     }
-                    if ((matcher = emptyMap.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("java.util.Collections.<K, T>emptyMap().values()")
+                            .genericTypes("K", "T")
+                            .build().matcher(getCursor())).find()) {
                         return SearchResult.found(elem);
                     }
                     return super.visitMethodInvocation(elem, ctx);
@@ -188,10 +176,16 @@ public class GenericsRecipes extends Recipe {
                 @Override
                 public J visitNewClass(J.NewClass elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = newList.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("new java.util.ArrayList<>()")
+                            .genericTypes("K", "T")
+                            .build().matcher(getCursor())).find()) {
                         return SearchResult.found(elem);
                     }
-                    if ((matcher = newMap.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("new java.util.HashMap<>()")
+                            .genericTypes("K", "T")
+                            .build().matcher(getCursor())).find()) {
                         return SearchResult.found(elem);
                     }
                     return super.visitNewClass(elem, ctx);
@@ -255,36 +249,32 @@ public class GenericsRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate wilcard1 = JavaTemplate
-                        .builder("#{cmp:any(java.util.Comparator<?>)}.thenComparingInt(null)")
-                        .genericTypes("T")
-                        .build();
-                final JavaTemplate wilcard2 = JavaTemplate
-                        .builder("#{cmp:any(java.util.Comparator<? extends java.lang.Number>)}.thenComparingInt(null)")
-                        .genericTypes("T")
-                        .build();
-                final JavaTemplate wilcard3 = JavaTemplate
-                        .builder("#{cmp:any(java.util.Comparator<T>)}.thenComparingInt(null)")
-                        .genericTypes("T")
-                        .build();
-                final JavaTemplate wilcard4 = JavaTemplate
-                        .builder("#{cmp:any(java.util.Comparator<? extends T>)}.thenComparingInt(null)")
-                        .genericTypes("T")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = wilcard1.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{cmp:any(java.util.Comparator<?>)}.thenComparingInt(null)")
+                            .genericTypes("T")
+                            .build().matcher(getCursor())).find()) {
                         return SearchResult.found(elem);
                     }
-                    if ((matcher = wilcard2.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{cmp:any(java.util.Comparator<? extends java.lang.Number>)}.thenComparingInt(null)")
+                            .genericTypes("T")
+                            .build().matcher(getCursor())).find()) {
                         return SearchResult.found(elem);
                     }
-                    if ((matcher = wilcard3.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{cmp:any(java.util.Comparator<T>)}.thenComparingInt(null)")
+                            .genericTypes("T")
+                            .build().matcher(getCursor())).find()) {
                         return SearchResult.found(elem);
                     }
-                    if ((matcher = wilcard4.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{cmp:any(java.util.Comparator<? extends T>)}.thenComparingInt(null)")
+                            .genericTypes("T")
+                            .build().matcher(getCursor())).find()) {
                         return SearchResult.found(elem);
                     }
                     return super.visitMethodInvocation(elem, ctx);

--- a/src/test/resources/refaster/LambdasRecipes.java
+++ b/src/test/resources/refaster/LambdasRecipes.java
@@ -88,19 +88,17 @@ public class LambdasRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{is:any(java.util.List<java.lang.Integer>)}.sort((x,y)->x - y);")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{is:any(java.util.List<java.lang.Integer>)}.sort(java.util.Comparator.comparingInt((x)->x));")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{is:any(java.util.List<java.lang.Integer>)}.sort((x,y)->x - y);")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("#{is:any(java.util.List<java.lang.Integer>)}.sort(java.util.Comparator.comparingInt((x)->x));")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES

--- a/src/test/resources/refaster/MatchOrderRecipe.java
+++ b/src/test/resources/refaster/MatchOrderRecipe.java
@@ -62,20 +62,13 @@ public class MatchOrderRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-            final JavaTemplate before1 = JavaTemplate
-                    .builder("#{str:any(java.lang.String)}.equals(#{literal:any(java.lang.String)})")
-                    .build();
-            final JavaTemplate before2 = JavaTemplate
-                    .builder("#{str:any(java.lang.String)}.equals(#{literal:any(java.lang.String)})")
-                    .build();
-            final JavaTemplate after = JavaTemplate
-                    .builder("#{literal:any(java.lang.String)}.equals(#{str:any(java.lang.String)})")
-                    .build();
 
             @Override
             public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
-                if ((matcher = before1.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("#{str:any(java.lang.String)}.equals(#{literal:any(java.lang.String)})")
+                        .build().matcher(getCursor())).find()) {
                     if (!new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(1))) {
                         return super.visitMethodInvocation(elem, ctx);
                     }
@@ -83,13 +76,17 @@ public class MatchOrderRecipe extends Recipe {
                         return super.visitMethodInvocation(elem, ctx);
                     }
                     return embed(
-                            after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(1), matcher.parameter(0)),
+                            JavaTemplate
+                                    .builder("#{literal:any(java.lang.String)}.equals(#{str:any(java.lang.String)})")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(1), matcher.parameter(0)),
                             getCursor(),
                             ctx,
                             SHORTEN_NAMES, SIMPLIFY_BOOLEANS
                     );
                 }
-                if ((matcher = before2.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("#{str:any(java.lang.String)}.equals(#{literal:any(java.lang.String)})")
+                        .build().matcher(getCursor())).find()) {
                     if (new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(0))) {
                         return super.visitMethodInvocation(elem, ctx);
                     }
@@ -97,7 +94,9 @@ public class MatchOrderRecipe extends Recipe {
                         return super.visitMethodInvocation(elem, ctx);
                     }
                     return embed(
-                            after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(1), matcher.parameter(0)),
+                            JavaTemplate
+                                    .builder("#{literal:any(java.lang.String)}.equals(#{str:any(java.lang.String)})")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(1), matcher.parameter(0)),
                             getCursor(),
                             ctx,
                             SHORTEN_NAMES, SIMPLIFY_BOOLEANS

--- a/src/test/resources/refaster/MatchingRecipes.java
+++ b/src/test/resources/refaster/MatchingRecipes.java
@@ -98,36 +98,35 @@ public class MatchingRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.substring(#{i:any(int)}).isEmpty()")
-                        .build();
-                final JavaTemplate before2 = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.substring(#{i:any(int)}).isEmpty()")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("(#{s:any(java.lang.String)} != null && #{s}.length() == 0)")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.substring(#{i:any(int)}).isEmpty()")
+                            .build().matcher(getCursor())).find()) {
                         if (new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(0))) {
                             return super.visitMethodInvocation(elem, ctx);
                         }
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("(#{s:any(java.lang.String)} != null && #{s}.length() == 0)")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 REMOVE_PARENS, SHORTEN_NAMES, SIMPLIFY_BOOLEANS
                         );
                     }
-                    if ((matcher = before2.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.substring(#{i:any(int)}).isEmpty()")
+                            .build().matcher(getCursor())).find()) {
                         if (!new org.openrewrite.java.template.MethodInvocationMatcher().matches((Expression) matcher.parameter(0))) {
                             return super.visitMethodInvocation(elem, ctx);
                         }
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("(#{s:any(java.lang.String)} != null && #{s}.length() == 0)")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 REMOVE_PARENS, SHORTEN_NAMES, SIMPLIFY_BOOLEANS

--- a/src/test/resources/refaster/MethodThrowsRecipe.java
+++ b/src/test/resources/refaster/MethodThrowsRecipe.java
@@ -60,20 +60,18 @@ public class MethodThrowsRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-            final JavaTemplate before = JavaTemplate
-                    .builder("java.nio.file.Files.readAllLines(#{path:any(java.nio.file.Path)}, java.nio.charset.StandardCharsets.UTF_8);")
-                    .build();
-            final JavaTemplate after = JavaTemplate
-                    .builder("java.nio.file.Files.readAllLines(#{path:any(java.nio.file.Path)});")
-                    .build();
 
             @Override
             public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
-                if ((matcher = before.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("java.nio.file.Files.readAllLines(#{path:any(java.nio.file.Path)}, java.nio.charset.StandardCharsets.UTF_8);")
+                        .build().matcher(getCursor())).find()) {
                     maybeRemoveImport("java.nio.charset.StandardCharsets");
                     return embed(
-                            after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                            JavaTemplate
+                                    .builder("java.nio.file.Files.readAllLines(#{path:any(java.nio.file.Path)});")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                             getCursor(),
                             ctx,
                             SHORTEN_NAMES

--- a/src/test/resources/refaster/MultimapGetRecipe.java
+++ b/src/test/resources/refaster/MultimapGetRecipe.java
@@ -62,33 +62,33 @@ public class MultimapGetRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-            final JavaTemplate before$0 = JavaTemplate
-                    .builder("#{multimap:any(java.util.Map<K, V>)}.keySet().contains(#{key:any(K)})")
-                    .genericTypes("K", "V")
-                    .build();
-            final JavaTemplate before$1 = JavaTemplate
-                    .builder("#{multimap:any(java.util.Map<K, V>)}.values().contains(#{key:any(K)})")
-                    .genericTypes("K", "V")
-                    .build();
-            final JavaTemplate after = JavaTemplate
-                    .builder("#{multimap:any(java.util.Map<K, V>)}.containsKey(#{key:any(K)})")
-                    .genericTypes("K", "V")
-                    .build();
 
             @Override
             public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
-                if ((matcher = before$0.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("#{multimap:any(java.util.Map<K, V>)}.keySet().contains(#{key:any(K)})")
+                        .genericTypes("K", "V")
+                        .build().matcher(getCursor())).find()) {
                     return embed(
-                            after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
+                            JavaTemplate
+                                    .builder("#{multimap:any(java.util.Map<K, V>)}.containsKey(#{key:any(K)})")
+                                    .genericTypes("K", "V")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
                             getCursor(),
                             ctx,
                             SHORTEN_NAMES, SIMPLIFY_BOOLEANS
                     );
                 }
-                if ((matcher = before$1.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("#{multimap:any(java.util.Map<K, V>)}.values().contains(#{key:any(K)})")
+                        .genericTypes("K", "V")
+                        .build().matcher(getCursor())).find()) {
                     return embed(
-                            after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
+                            JavaTemplate
+                                    .builder("#{multimap:any(java.util.Map<K, V>)}.containsKey(#{key:any(K)})")
+                                    .genericTypes("K", "V")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
                             getCursor(),
                             ctx,
                             SHORTEN_NAMES, SIMPLIFY_BOOLEANS

--- a/src/test/resources/refaster/MultipleDereferencesRecipes.java
+++ b/src/test/resources/refaster/MultipleDereferencesRecipes.java
@@ -90,19 +90,17 @@ public class MultipleDereferencesRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("java.nio.file.Files.delete(#{p:any(java.nio.file.Path)});")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("java.nio.file.Files.delete(#{p:any(java.nio.file.Path)});")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("java.nio.file.Files.delete(#{p:any(java.nio.file.Path)});")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("java.nio.file.Files.delete(#{p:any(java.nio.file.Path)});")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
@@ -149,19 +147,17 @@ public class MultipleDereferencesRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.isEmpty()")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{s:any(java.lang.String)} != null && #{s}.length() == 0")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.isEmpty()")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String)} != null && #{s}.length() == 0")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -204,19 +200,17 @@ public class MultipleDereferencesRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             return new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{o:any(java.lang.Object)} == #{o}")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("true")
-                        .build();
 
                 @Override
                 public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{o:any(java.lang.Object)} == #{o}")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace()),
+                                JavaTemplate
+                                        .builder("true")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace()),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS

--- a/src/test/resources/refaster/NestedPreconditionsRecipe.java
+++ b/src/test/resources/refaster/NestedPreconditionsRecipe.java
@@ -60,32 +60,31 @@ public class NestedPreconditionsRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-            final JavaTemplate hashMap = JavaTemplate
-                    .builder("new java.util.HashMap(#{size:any(int)})")
-                    .build();
-            final JavaTemplate linkedHashMap = JavaTemplate
-                    .builder("new java.util.LinkedHashMap(#{size:any(int)})")
-                    .build();
-            final JavaTemplate hashtable = JavaTemplate
-                    .builder("new java.util.Hashtable(#{size:any(int)})")
-                    .build();
 
             @Override
             public J visitNewClass(J.NewClass elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
-                if ((matcher = hashMap.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("new java.util.HashMap(#{size:any(int)})")
+                        .build().matcher(getCursor())).find()) {
                     maybeRemoveImport("java.util.HashMap");
                     return embed(
-                            hashtable.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                            JavaTemplate
+                                    .builder("new java.util.Hashtable(#{size:any(int)})")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                             getCursor(),
                             ctx,
                             SHORTEN_NAMES
                     );
                 }
-                if ((matcher = linkedHashMap.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("new java.util.LinkedHashMap(#{size:any(int)})")
+                        .build().matcher(getCursor())).find()) {
                     maybeRemoveImport("java.util.LinkedHashMap");
                     return embed(
-                            hashtable.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                            JavaTemplate
+                                    .builder("new java.util.Hashtable(#{size:any(int)})")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                             getCursor(),
                             ctx,
                             SHORTEN_NAMES

--- a/src/test/resources/refaster/NewBufferedWriterRecipe.java
+++ b/src/test/resources/refaster/NewBufferedWriterRecipe.java
@@ -60,20 +60,18 @@ public class NewBufferedWriterRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-            final JavaTemplate before = JavaTemplate
-                    .builder("new java.io.BufferedWriter(new java.io.FileWriter(#{f:any(java.lang.String)}, #{b:any(java.lang.Boolean)}))")
-                    .build();
-            final JavaTemplate after = JavaTemplate
-                    .builder("java.nio.file.Files.newBufferedWriter(new java.io.File(#{f:any(java.lang.String)}).toPath(), #{b:any(java.lang.Boolean)} ? java.nio.file.StandardOpenOption.APPEND : java.nio.file.StandardOpenOption.CREATE)")
-                    .build();
 
             @Override
             public J visitNewClass(J.NewClass elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
-                if ((matcher = before.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("new java.io.BufferedWriter(new java.io.FileWriter(#{f:any(java.lang.String)}, #{b:any(java.lang.Boolean)}))")
+                        .build().matcher(getCursor())).find()) {
                     maybeRemoveImport("java.io.FileWriter");
                     return embed(
-                            after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
+                            JavaTemplate
+                                    .builder("java.nio.file.Files.newBufferedWriter(new java.io.File(#{f:any(java.lang.String)}).toPath(), #{b:any(java.lang.Boolean)} ? java.nio.file.StandardOpenOption.APPEND : java.nio.file.StandardOpenOption.CREATE)")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
                             getCursor(),
                             ctx,
                             SHORTEN_NAMES, SIMPLIFY_BOOLEANS

--- a/src/test/resources/refaster/OrElseGetGetRecipe.java
+++ b/src/test/resources/refaster/OrElseGetGetRecipe.java
@@ -62,21 +62,19 @@ public class OrElseGetGetRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-            final JavaTemplate before = JavaTemplate
-                    .builder("#{o1:any(java.util.Optional<T>)}.orElseGet(()->#{o2:any(java.util.Optional<T>)}.get())")
-                    .genericTypes("T")
-                    .build();
-            final JavaTemplate after = JavaTemplate
-                    .builder("#{o1:any(java.util.Optional<T>)}.orElseGet(#{o2:any(java.util.Optional<T>)}::get)")
-                    .genericTypes("T")
-                    .build();
 
             @Override
             public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
-                if ((matcher = before.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("#{o1:any(java.util.Optional<T>)}.orElseGet(()->#{o2:any(java.util.Optional<T>)}.get())")
+                        .genericTypes("T")
+                        .build().matcher(getCursor())).find()) {
                     return embed(
-                            after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
+                            JavaTemplate
+                                    .builder("#{o1:any(java.util.Optional<T>)}.orElseGet(#{o2:any(java.util.Optional<T>)}::get)")
+                                    .genericTypes("T")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
                             getCursor(),
                             ctx,
                             SHORTEN_NAMES

--- a/src/test/resources/refaster/ParameterOrderRecipe.java
+++ b/src/test/resources/refaster/ParameterOrderRecipe.java
@@ -62,19 +62,17 @@ public class ParameterOrderRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new AbstractRefasterJavaVisitor() {
-            final JavaTemplate parameters = JavaTemplate
-                    .builder("#{a:any(int)} + #{b:any(int)}")
-                    .build();
-            final JavaTemplate output = JavaTemplate
-                    .builder("#{a:any(int)} + #{a} + #{b:any(int)}")
-                    .build();
 
             @Override
             public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
-                if ((matcher = parameters.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("#{a:any(int)} + #{b:any(int)}")
+                        .build().matcher(getCursor())).find()) {
                     return embed(
-                            output.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
+                            JavaTemplate
+                                    .builder("#{a:any(int)} + #{a} + #{b:any(int)}")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
                             getCursor(),
                             ctx,
                             SHORTEN_NAMES

--- a/src/test/resources/refaster/ParametersRecipes.java
+++ b/src/test/resources/refaster/ParametersRecipes.java
@@ -95,19 +95,17 @@ public class ParametersRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             return new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String)} == #{s}")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.equals(#{s})")
-                        .build();
 
                 @Override
                 public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)} == #{s}")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String)}.equals(#{s})")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -148,19 +146,17 @@ public class ParametersRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             return new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String[])} == #{s}")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{s:any(java.lang.String[])}.equals(#{s})")
-                        .build();
 
                 @Override
                 public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String[])} == #{s}")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String[])}.equals(#{s})")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -201,19 +197,17 @@ public class ParametersRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             return new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String)} == #{s}")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.equals(#{s})")
-                        .build();
 
                 @Override
                 public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)} == #{s}")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String)}.equals(#{s})")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -254,30 +248,29 @@ public class ParametersRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             return new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before1 = JavaTemplate
-                        .builder("#{a:any(int)} == #{b:any(int)}")
-                        .build();
-                final JavaTemplate before2 = JavaTemplate
-                        .builder("#{b:any(int)} == #{a:any(int)}")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{a:any(int)} == #{b:any(int)}")
-                        .build();
 
                 @Override
                 public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before1.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{a:any(int)} == #{b:any(int)}")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
+                                JavaTemplate
+                                        .builder("#{a:any(int)} == #{b:any(int)}")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
                         );
                     }
-                    if ((matcher = before2.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{b:any(int)} == #{a:any(int)}")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(1), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("#{a:any(int)} == #{b:any(int)}")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(1), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS

--- a/src/test/resources/refaster/PicnicRulesRecipes.java
+++ b/src/test/resources/refaster/PicnicRulesRecipes.java
@@ -92,19 +92,17 @@ public class PicnicRulesRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -147,19 +145,17 @@ public class PicnicRulesRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -202,19 +198,17 @@ public class PicnicRulesRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -257,19 +251,17 @@ public class PicnicRulesRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -312,19 +304,17 @@ public class PicnicRulesRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS

--- a/src/test/resources/refaster/PreconditionsVerifierRecipes.java
+++ b/src/test/resources/refaster/PreconditionsVerifierRecipes.java
@@ -96,30 +96,29 @@ public class PreconditionsVerifierRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("System.out.println(#{actual:any(double)});")
-                        .build();
-                final JavaTemplate before0 = JavaTemplate
-                        .builder("System.out.println(#{actual:any(java.lang.String)});")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("System.out.println(\"Changed: \" + #{actual:any(java.lang.Object)});")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("System.out.println(#{actual:any(double)});")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("System.out.println(\"Changed: \" + #{actual:any(java.lang.Object)});")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
                         );
                     }
-                    if ((matcher = before0.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("System.out.println(#{actual:any(java.lang.String)});")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("System.out.println(\"Changed: \" + #{actual:any(java.lang.Object)});")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
@@ -162,32 +161,32 @@ public class PreconditionsVerifierRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("com.sun.tools.javac.util.Convert.quote(#{value:any(java.lang.String)})")
-                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
-                        .build();
-                final JavaTemplate before0 = JavaTemplate
-                        .builder("String.valueOf(#{value:any(int)})")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("com.sun.tools.javac.util.Convert.quote(String.valueOf(#{value:any(java.lang.Object)}))")
-                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("com.sun.tools.javac.util.Convert.quote(#{value:any(java.lang.String)})")
+                            .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("com.sun.tools.javac.util.Convert.quote(String.valueOf(#{value:any(java.lang.Object)}))")
+                                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
                         );
                     }
-                    if ((matcher = before0.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("String.valueOf(#{value:any(int)})")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("com.sun.tools.javac.util.Convert.quote(String.valueOf(#{value:any(java.lang.Object)}))")
+                                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
@@ -236,33 +235,33 @@ public class PreconditionsVerifierRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("com.sun.tools.javac.util.Convert.quote(#{value:any(java.lang.String)})")
-                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
-                        .build();
-                final JavaTemplate before0 = JavaTemplate
-                        .builder("com.sun.tools.javac.util.Convert.quote(String.valueOf(#{value:any(int)}))")
-                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("com.sun.tools.javac.util.Convert.quote(String.valueOf(#{value:any(java.lang.Object)}))")
-                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("com.sun.tools.javac.util.Convert.quote(#{value:any(java.lang.String)})")
+                            .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("com.sun.tools.javac.util.Convert.quote(String.valueOf(#{value:any(java.lang.Object)}))")
+                                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
                         );
                     }
-                    if ((matcher = before0.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("com.sun.tools.javac.util.Convert.quote(String.valueOf(#{value:any(int)}))")
+                            .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("com.sun.tools.javac.util.Convert.quote(String.valueOf(#{value:any(java.lang.Object)}))")
+                                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
@@ -308,31 +307,30 @@ public class PreconditionsVerifierRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("System.out.println(#{actual:any(int)});")
-                        .build();
-                final JavaTemplate before0 = JavaTemplate
-                        .builder("System.out.println(#{actual:any(java.util.Map<?, ?>)});")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("System.out.println(\"Changed: \" + #{actual:any(java.lang.Object)});")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("System.out.println(#{actual:any(int)});")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("System.out.println(\"Changed: \" + #{actual:any(java.lang.Object)});")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
                         );
                     }
-                    if ((matcher = before0.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("System.out.println(#{actual:any(java.util.Map<?, ?>)});")
+                            .build().matcher(getCursor())).find()) {
                         maybeRemoveImport("java.util.Map");
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("System.out.println(\"Changed: \" + #{actual:any(java.lang.Object)});")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
@@ -375,31 +373,30 @@ public class PreconditionsVerifierRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("System.out.println(#{actual:any(java.lang.String)});")
-                        .build();
-                final JavaTemplate before0 = JavaTemplate
-                        .builder("System.out.println(#{actual:any(java.util.Map<?, ?>)});")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("System.out.println(\"Changed: \" + #{actual:any(java.lang.Object)});")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("System.out.println(#{actual:any(java.lang.String)});")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("System.out.println(\"Changed: \" + #{actual:any(java.lang.Object)});")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
                         );
                     }
-                    if ((matcher = before0.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("System.out.println(#{actual:any(java.util.Map<?, ?>)});")
+                            .build().matcher(getCursor())).find()) {
                         maybeRemoveImport("java.util.Map");
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("System.out.println(\"Changed: \" + #{actual:any(java.lang.Object)});")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
@@ -442,30 +439,29 @@ public class PreconditionsVerifierRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate mapWithGeneric = JavaTemplate
-                        .builder("System.out.println(#{actual:any(java.util.Map<?, ?>)});")
-                        .build();
-                final JavaTemplate mapWithGenericTwo = JavaTemplate
-                        .builder("System.out.println(#{actual:any(java.util.Map<?, ?>)});")
-                        .build();
-                final JavaTemplate mapWithoutGeneric = JavaTemplate
-                        .builder("System.out.println(\"Changed: \" + #{actual:any(java.util.Map)});")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = mapWithGeneric.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("System.out.println(#{actual:any(java.util.Map<?, ?>)});")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                mapWithoutGeneric.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("System.out.println(\"Changed: \" + #{actual:any(java.util.Map)});")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
                         );
                     }
-                    if ((matcher = mapWithGenericTwo.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("System.out.println(#{actual:any(java.util.Map<?, ?>)});")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                mapWithoutGeneric.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("System.out.println(\"Changed: \" + #{actual:any(java.util.Map)});")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
@@ -511,32 +507,31 @@ public class PreconditionsVerifierRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("System.out.println(#{actual:any(java.util.List<?>)});")
-                        .build();
-                final JavaTemplate before0 = JavaTemplate
-                        .builder("System.out.println(#{actual:any(java.util.Map<?, ?>)});")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("System.out.println(\"Changed: \" + #{actual:any(java.lang.Object)});")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("System.out.println(#{actual:any(java.util.List<?>)});")
+                            .build().matcher(getCursor())).find()) {
                         maybeRemoveImport("java.util.List");
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("System.out.println(\"Changed: \" + #{actual:any(java.lang.Object)});")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
                         );
                     }
-                    if ((matcher = before0.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("System.out.println(#{actual:any(java.util.Map<?, ?>)});")
+                            .build().matcher(getCursor())).find()) {
                         maybeRemoveImport("java.util.Map");
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("System.out.println(\"Changed: \" + #{actual:any(java.lang.Object)});")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES

--- a/src/test/resources/refaster/RefasterAnyOfRecipes.java
+++ b/src/test/resources/refaster/RefasterAnyOfRecipes.java
@@ -95,30 +95,29 @@ public class RefasterAnyOfRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before$0 = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.length() < 1")
-                        .build();
-                final JavaTemplate before$1 = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.length() == 0")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.isEmpty()")
-                        .build();
 
                 @Override
                 public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before$0.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.length() < 1")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String)}.isEmpty()")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
                         );
                     }
-                    if ((matcher = before$1.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.length() == 0")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String)}.isEmpty()")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -163,32 +162,31 @@ public class RefasterAnyOfRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before$0 = JavaTemplate
-                        .builder("new java.util.LinkedList()")
-                        .build();
-                final JavaTemplate before$1 = JavaTemplate
-                        .builder("java.util.Collections.emptyList()")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("new java.util.ArrayList()")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before$0.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("new java.util.LinkedList()")
+                            .build().matcher(getCursor())).find()) {
                         maybeRemoveImport("java.util.LinkedList");
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace()),
+                                JavaTemplate
+                                        .builder("new java.util.ArrayList()")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace()),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
                         );
                     }
-                    if ((matcher = before$1.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("java.util.Collections.emptyList()")
+                            .build().matcher(getCursor())).find()) {
                         maybeRemoveImport("java.util.Collections");
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace()),
+                                JavaTemplate
+                                        .builder("new java.util.ArrayList()")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace()),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
@@ -200,19 +198,27 @@ public class RefasterAnyOfRecipes extends Recipe {
                 @Override
                 public J visitNewClass(J.NewClass elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before$0.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("new java.util.LinkedList()")
+                            .build().matcher(getCursor())).find()) {
                         maybeRemoveImport("java.util.LinkedList");
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace()),
+                                JavaTemplate
+                                        .builder("new java.util.ArrayList()")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace()),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
                         );
                     }
-                    if ((matcher = before$1.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("java.util.Collections.emptyList()")
+                            .build().matcher(getCursor())).find()) {
                         maybeRemoveImport("java.util.Collections");
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace()),
+                                JavaTemplate
+                                        .builder("new java.util.ArrayList()")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace()),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
@@ -269,30 +275,29 @@ public class RefasterAnyOfRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before$0 = JavaTemplate
-                        .builder("String.valueOf(#{data:any(char[])}, #{offset:any(int)}, #{count:any(int)})")
-                        .build();
-                final JavaTemplate before$1 = JavaTemplate
-                        .builder("String.copyValueOf(#{data:any(char[])}, #{offset:any(int)}, #{count:any(int)})")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("new String(#{data:any(char[])}, #{offset:any(int)}, #{count:any(int)})")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before$0.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("String.valueOf(#{data:any(char[])}, #{offset:any(int)}, #{count:any(int)})")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
+                                JavaTemplate
+                                        .builder("new String(#{data:any(char[])}, #{offset:any(int)}, #{count:any(int)})")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
                         );
                     }
-                    if ((matcher = before$1.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("String.copyValueOf(#{data:any(char[])}, #{offset:any(int)}, #{count:any(int)})")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
+                                JavaTemplate
+                                        .builder("new String(#{data:any(char[])}, #{offset:any(int)}, #{count:any(int)})")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
@@ -340,30 +345,29 @@ public class RefasterAnyOfRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before$0 = JavaTemplate
-                        .builder("java.time.Duration.between(#{a:any(java.time.OffsetDateTime)}.toInstant(), #{b:any(java.time.OffsetDateTime)}.toInstant())")
-                        .build();
-                final JavaTemplate before$1 = JavaTemplate
-                        .builder("java.time.Duration.ofSeconds(#{b:any(java.time.OffsetDateTime)}.toEpochSecond() - #{a:any(java.time.OffsetDateTime)}.toEpochSecond())")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("java.time.Duration.between(#{a:any(java.time.OffsetDateTime)}, #{b:any(java.time.OffsetDateTime)})")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before$0.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("java.time.Duration.between(#{a:any(java.time.OffsetDateTime)}.toInstant(), #{b:any(java.time.OffsetDateTime)}.toInstant())")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
+                                JavaTemplate
+                                        .builder("java.time.Duration.between(#{a:any(java.time.OffsetDateTime)}, #{b:any(java.time.OffsetDateTime)})")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
                         );
                     }
-                    if ((matcher = before$1.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("java.time.Duration.ofSeconds(#{b:any(java.time.OffsetDateTime)}.toEpochSecond() - #{a:any(java.time.OffsetDateTime)}.toEpochSecond())")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(1), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("java.time.Duration.between(#{a:any(java.time.OffsetDateTime)}, #{b:any(java.time.OffsetDateTime)})")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(1), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES

--- a/src/test/resources/refaster/ShouldAddImportsRecipes.java
+++ b/src/test/resources/refaster/ShouldAddImportsRecipes.java
@@ -93,19 +93,17 @@ public class ShouldAddImportsRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("String.valueOf(#{s:any(java.lang.String)})")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("java.util.Objects.toString(#{s:any(java.lang.String)})")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("String.valueOf(#{s:any(java.lang.String)})")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("java.util.Objects.toString(#{s:any(java.lang.String)})")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
@@ -148,22 +146,17 @@ public class ShouldAddImportsRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate equals = JavaTemplate
-                        .builder("java.util.Objects.equals(#{a:any(int)}, #{b:any(int)})")
-                        .build();
-                final JavaTemplate compareZero = JavaTemplate
-                        .builder("Integer.compare(#{a:any(int)}, #{b:any(int)}) == 0")
-                        .build();
-                final JavaTemplate isis = JavaTemplate
-                        .builder("#{a:any(int)} == #{b:any(int)}")
-                        .build();
 
                 @Override
                 public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = compareZero.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("Integer.compare(#{a:any(int)}, #{b:any(int)}) == 0")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                isis.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
+                                JavaTemplate
+                                        .builder("#{a:any(int)} == #{b:any(int)}")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -175,10 +168,14 @@ public class ShouldAddImportsRecipes extends Recipe {
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = equals.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("java.util.Objects.equals(#{a:any(int)}, #{b:any(int)})")
+                            .build().matcher(getCursor())).find()) {
                         maybeRemoveImport("java.util.Objects");
                         return embed(
-                                isis.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
+                                JavaTemplate
+                                        .builder("#{a:any(int)} == #{b:any(int)}")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -227,20 +224,18 @@ public class ShouldAddImportsRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("java.util.Objects.hash(#{s:any(java.lang.String)})")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.hashCode()")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("java.util.Objects.hash(#{s:any(java.lang.String)})")
+                            .build().matcher(getCursor())).find()) {
                         maybeRemoveImport("java.util.Objects.hash");
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String)}.hashCode()")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES
@@ -283,19 +278,17 @@ public class ShouldAddImportsRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{path:any(java.nio.file.Path)}.toFile().exists()")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("java.nio.file.Files.exists(#{path:any(java.nio.file.Path)})")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{path:any(java.nio.file.Path)}.toFile().exists()")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("java.nio.file.Files.exists(#{path:any(java.nio.file.Path)})")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -342,14 +335,13 @@ public class ShouldAddImportsRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.isEmpty()")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.isEmpty()")
+                            .build().matcher(getCursor())).find()) {
                         return SearchResult.found(elem);
                     }
                     return super.visitMethodInvocation(elem, ctx);

--- a/src/test/resources/refaster/ShouldSupportNestedClassesRecipes.java
+++ b/src/test/resources/refaster/ShouldSupportNestedClassesRecipes.java
@@ -90,19 +90,17 @@ public class ShouldSupportNestedClassesRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.length() > 0")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("!#{s:any(java.lang.String)}.isEmpty()")
-                        .build();
 
                 @Override
                 public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.length() > 0")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("!#{s:any(java.lang.String)}.isEmpty()")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -145,19 +143,17 @@ public class ShouldSupportNestedClassesRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.length() == 0")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.isEmpty()")
-                        .build();
 
                 @Override
                 public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.length() == 0")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String)}.isEmpty()")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS

--- a/src/test/resources/refaster/SimplifyBooleansRecipe.java
+++ b/src/test/resources/refaster/SimplifyBooleansRecipe.java
@@ -61,19 +61,17 @@ public class SimplifyBooleansRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-            final JavaTemplate before = JavaTemplate
-                    .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
-                    .build();
-            final JavaTemplate after = JavaTemplate
-                    .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
-                    .build();
 
             @Override
             public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
-                if ((matcher = before.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
+                        .build().matcher(getCursor())).find()) {
                     return embed(
-                            after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
+                            JavaTemplate
+                                    .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
                             getCursor(),
                             ctx,
                             SHORTEN_NAMES, SIMPLIFY_BOOLEANS

--- a/src/test/resources/refaster/SimplifyTernaryRecipes.java
+++ b/src/test/resources/refaster/SimplifyTernaryRecipes.java
@@ -89,19 +89,17 @@ public class SimplifyTernaryRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             return new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{expr:any(boolean)} ? true : false")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{expr:any(boolean)}")
-                        .build();
 
                 @Override
                 public J visitTernary(J.Ternary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{expr:any(boolean)} ? true : false")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("#{expr:any(boolean)}")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -140,19 +138,17 @@ public class SimplifyTernaryRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             return new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{expr:any(boolean)} ? false : true")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("!(#{expr:any(boolean)})")
-                        .build();
 
                 @Override
                 public J visitTernary(J.Ternary elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{expr:any(boolean)} ? false : true")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                                JavaTemplate
+                                        .builder("!(#{expr:any(boolean)})")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
                                 REMOVE_PARENS, SHORTEN_NAMES, SIMPLIFY_BOOLEANS

--- a/src/test/resources/refaster/SuppressedWarningsAsTagsRecipes.java
+++ b/src/test/resources/refaster/SuppressedWarningsAsTagsRecipes.java
@@ -102,19 +102,17 @@ public class SuppressedWarningsAsTagsRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -164,19 +162,17 @@ public class SuppressedWarningsAsTagsRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -226,19 +222,17 @@ public class SuppressedWarningsAsTagsRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -288,19 +282,17 @@ public class SuppressedWarningsAsTagsRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -350,19 +342,17 @@ public class SuppressedWarningsAsTagsRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -412,19 +402,17 @@ public class SuppressedWarningsAsTagsRecipes extends Recipe {
         @Override
         public TreeVisitor<?, ExecutionContext> getVisitor() {
             JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-                final JavaTemplate before = JavaTemplate
-                        .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
-                        .build();
-                final JavaTemplate after = JavaTemplate
-                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
-                        .build();
 
                 @Override
                 public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                     JavaTemplate.Matcher matcher;
-                    if ((matcher = before.matcher(getCursor())).find()) {
+                    if ((matcher = JavaTemplate
+                            .builder("#{s:any(java.lang.String)}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)})")
+                            .build().matcher(getCursor())).find()) {
                         return embed(
-                                after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
+                                JavaTemplate
+                                        .builder("#{s:any(java.lang.String)} != null ? #{s}.replaceAll(#{s1:any(java.lang.String)}, #{s2:any(java.lang.String)}) : #{s}")
+                                        .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1), matcher.parameter(2)),
                                 getCursor(),
                                 ctx,
                                 SHORTEN_NAMES, SIMPLIFY_BOOLEANS

--- a/src/test/resources/refaster/TwoVisitMethodsRecipe.java
+++ b/src/test/resources/refaster/TwoVisitMethodsRecipe.java
@@ -60,22 +60,17 @@ public class TwoVisitMethodsRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-            final JavaTemplate lengthIsZero = JavaTemplate
-                    .builder("#{s:any(java.lang.String)}.length() == 0")
-                    .build();
-            final JavaTemplate equalsEmptyString = JavaTemplate
-                    .builder("#{s:any(java.lang.String)}.equals(\"\")")
-                    .build();
-            final JavaTemplate isEmpty = JavaTemplate
-                    .builder("#{s:any(java.lang.String)}.isEmpty()")
-                    .build();
 
             @Override
             public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
-                if ((matcher = lengthIsZero.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("#{s:any(java.lang.String)}.length() == 0")
+                        .build().matcher(getCursor())).find()) {
                     return embed(
-                            isEmpty.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                            JavaTemplate
+                                    .builder("#{s:any(java.lang.String)}.isEmpty()")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                             getCursor(),
                             ctx,
                             SHORTEN_NAMES, SIMPLIFY_BOOLEANS
@@ -87,9 +82,13 @@ public class TwoVisitMethodsRecipe extends Recipe {
             @Override
             public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
-                if ((matcher = equalsEmptyString.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("#{s:any(java.lang.String)}.equals(\"\")")
+                        .build().matcher(getCursor())).find()) {
                     return embed(
-                            isEmpty.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                            JavaTemplate
+                                    .builder("#{s:any(java.lang.String)}.isEmpty()")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                             getCursor(),
                             ctx,
                             SHORTEN_NAMES, SIMPLIFY_BOOLEANS

--- a/src/test/resources/refaster/UnnamedPackageRecipe.java
+++ b/src/test/resources/refaster/UnnamedPackageRecipe.java
@@ -59,19 +59,17 @@ public class UnnamedPackageRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new AbstractRefasterJavaVisitor() {
-            final JavaTemplate before = JavaTemplate
-                    .builder("\"This class is located in the default package\"")
-                    .build();
-            final JavaTemplate after = JavaTemplate
-                    .builder("\"And that doesn\\'t cause any problems\"")
-                    .build();
 
             @Override
             public J visitExpression(Expression elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
-                if ((matcher = before.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("\"This class is located in the default package\"")
+                        .build().matcher(getCursor())).find()) {
                     return embed(
-                            after.apply(getCursor(), elem.getCoordinates().replace()),
+                            JavaTemplate
+                                    .builder("\"And that doesn\\'t cause any problems\"")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace()),
                             getCursor(),
                             ctx,
                             SHORTEN_NAMES

--- a/src/test/resources/refaster/UseStringIsEmptyRecipe.java
+++ b/src/test/resources/refaster/UseStringIsEmptyRecipe.java
@@ -61,19 +61,17 @@ public class UseStringIsEmptyRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
-            final JavaTemplate before = JavaTemplate
-                    .builder("#{s:any(java.lang.String)}.length() > 0")
-                    .build();
-            final JavaTemplate after = JavaTemplate
-                    .builder("!(#{s:any(java.lang.String)}.isEmpty())")
-                    .build();
 
             @Override
             public J visitBinary(J.Binary elem, ExecutionContext ctx) {
                 JavaTemplate.Matcher matcher;
-                if ((matcher = before.matcher(getCursor())).find()) {
+                if ((matcher = JavaTemplate
+                        .builder("#{s:any(java.lang.String)}.length() > 0")
+                        .build().matcher(getCursor())).find()) {
                     return embed(
-                            after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
+                            JavaTemplate
+                                    .builder("!(#{s:any(java.lang.String)}.isEmpty())")
+                                    .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                             getCursor(),
                             ctx,
                             REMOVE_PARENS, SHORTEN_NAMES, SIMPLIFY_BOOLEANS


### PR DESCRIPTION
## What's changed?
When generating refaster recipes recipes from remaster template recipes the variable for `before` and `after` are removed and the Objects are instantiated inline.

## What's your motivation?
Fixes: 
- https://github.com/moderneinc/customer-requests/issues/1135
