### PR TITLE
Added implementation for classpathFromResource in refasten templates

### DIFF
--- a/src/main/java/org/openrewrite/java/template/internal/TemplateCode.java
+++ b/src/main/java/org/openrewrite/java/template/internal/TemplateCode.java
@@ -70,7 +70,11 @@ public class TemplateCode {
                 // See https://github.com/openrewrite/rewrite-templating/issues/86
                 // String classpath = jarNames.stream().map(jarName -> '"' + jarName + '"').sorted().collect(joining(", "));
                 // builder.append("\n    .javaParser(JavaParser.fromJavaVersion().classpath(").append(classpath).append("))");
-                builder.append("\n    .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))");
+                // builder.append("\n    .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))");
+                builder.append("\n    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, ");
+                builder.append(jarNames.stream().map(jarName -> '"' + jarName + '"').collect(joining(", ")));
+                builder.append("))\n    ");
+
             }
             return builder.toString();
         } catch (IOException e) {

--- a/src/test/resources/refaster/EscapesRecipes.java
+++ b/src/test/resources/refaster/EscapesRecipes.java
@@ -95,13 +95,13 @@ public class EscapesRecipes extends Recipe {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = JavaTemplate
                             .builder("String.format(\"\\\"%s\\\"\", com.sun.tools.javac.util.Convert.quote(#{value:any(java.lang.String)}))")
-                            .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "tools"))
                             .build().matcher(getCursor())).find()) {
                         maybeRemoveImport("com.sun.tools.javac.util.Convert");
                         return embed(
                                 JavaTemplate
                                         .builder("com.sun.tools.javac.util.Constants.format(#{value:any(java.lang.String)})")
-                                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "tools"))
                                         .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,

--- a/src/test/resources/refaster/PreconditionsVerifierRecipes.java
+++ b/src/test/resources/refaster/PreconditionsVerifierRecipes.java
@@ -167,12 +167,12 @@ public class PreconditionsVerifierRecipes extends Recipe {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = JavaTemplate
                             .builder("com.sun.tools.javac.util.Convert.quote(#{value:any(java.lang.String)})")
-                            .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "tools"))
                             .build().matcher(getCursor())).find()) {
                         return embed(
                                 JavaTemplate
                                         .builder("com.sun.tools.javac.util.Convert.quote(String.valueOf(#{value:any(java.lang.Object)}))")
-                                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "tools"))
                                         .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
@@ -185,7 +185,7 @@ public class PreconditionsVerifierRecipes extends Recipe {
                         return embed(
                                 JavaTemplate
                                         .builder("com.sun.tools.javac.util.Convert.quote(String.valueOf(#{value:any(java.lang.Object)}))")
-                                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "tools"))
                                         .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
@@ -241,12 +241,12 @@ public class PreconditionsVerifierRecipes extends Recipe {
                     JavaTemplate.Matcher matcher;
                     if ((matcher = JavaTemplate
                             .builder("com.sun.tools.javac.util.Convert.quote(#{value:any(java.lang.String)})")
-                            .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "tools"))
                             .build().matcher(getCursor())).find()) {
                         return embed(
                                 JavaTemplate
                                         .builder("com.sun.tools.javac.util.Convert.quote(String.valueOf(#{value:any(java.lang.Object)}))")
-                                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "tools"))
                                         .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
@@ -255,12 +255,12 @@ public class PreconditionsVerifierRecipes extends Recipe {
                     }
                     if ((matcher = JavaTemplate
                             .builder("com.sun.tools.javac.util.Convert.quote(String.valueOf(#{value:any(int)}))")
-                            .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "tools"))
                             .build().matcher(getCursor())).find()) {
                         return embed(
                                 JavaTemplate
                                         .builder("com.sun.tools.javac.util.Convert.quote(String.valueOf(#{value:any(java.lang.Object)}))")
-                                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "tools"))
                                         .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,


### PR DESCRIPTION
## What's changed?
Changed implementation in TemplateCode when generating refaster recipes to use classPathFromResource

## What's your motivation?
Fixes:
- https://github.com/moderneinc/customer-requests/issues/1136
