### PR TITLE
Support adding static imports for method invocations

### DIFF
--- a/src/main/java/org/openrewrite/java/template/internal/AbstractRefasterJavaVisitor.java
+++ b/src/main/java/org/openrewrite/java/template/internal/AbstractRefasterJavaVisitor.java
@@ -19,7 +19,6 @@ import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaVisitor;
-import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.UseStaticImport;
 import org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor;
 import org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor;
@@ -27,6 +26,8 @@ import org.openrewrite.java.service.ImportService;
 import org.openrewrite.java.tree.J;
 
 import java.util.EnumSet;
+
+import static org.openrewrite.java.MethodMatcher.methodPattern;
 
 @SuppressWarnings("unused")
 public abstract class AbstractRefasterJavaVisitor extends JavaVisitor<ExecutionContext> {
@@ -47,10 +48,9 @@ public abstract class AbstractRefasterJavaVisitor extends JavaVisitor<ExecutionC
             j = new SimplifyBooleanExpressionVisitor().visitNonNull(j, ctx, cursor.getParentOrThrow());
         }
         if (optionsSet.contains(EmbeddingOption.STATIC_IMPORT_ALWAYS) && j instanceof J.MethodInvocation) {
-            J.MethodInvocation methodInvocation = (J.MethodInvocation) j;
-            if (methodInvocation.getSelect() != null && methodInvocation.getMethodType() != null) {
-                String methodPattern = MethodMatcher.methodPattern(methodInvocation.getMethodType());
-                doAfterVisit(new UseStaticImport(methodPattern).getVisitor());
+            J.MethodInvocation mi = (J.MethodInvocation) j;
+            if (mi.getSelect() != null && mi.getMethodType() != null) {
+                doAfterVisit(new UseStaticImport(methodPattern(mi.getMethodType())).getVisitor());
             }
         }
         return j;

--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -418,8 +418,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                         if (simplifyBooleans(descriptor.afterTemplate.method)) {
                             embedOptions.add("SIMPLIFY_BOOLEANS");
                         }
-                        List<JCTree.JCAnnotation> useImportPolicyAnnotations = getTemplateAnnotations(descriptor.afterTemplate.method, USE_IMPORT_POLICY::equals);
-                        if (!useImportPolicyAnnotations.isEmpty()) {
+                        if (!getTemplateAnnotations(descriptor.afterTemplate.method, USE_IMPORT_POLICY::equals).isEmpty()) {
                             // Assume ImportPolicy.STATIC_IMPORT_ALWAYS, as that's all we see in error-prone-support
                             embedOptions.add("STATIC_IMPORT_ALWAYS");
                         }

--- a/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
+++ b/src/main/java/org/openrewrite/java/template/processor/RefasterTemplateProcessor.java
@@ -69,6 +69,7 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
 
     static final String BEFORE_TEMPLATE = "com.google.errorprone.refaster.annotation.BeforeTemplate";
     static final String AFTER_TEMPLATE = "com.google.errorprone.refaster.annotation.AfterTemplate";
+    static final String USE_IMPORT_POLICY = "com.google.errorprone.refaster.annotation.UseImportPolicy";
     static Set<String> UNSUPPORTED_ANNOTATIONS = Stream.of(
             "com.google.errorprone.refaster.annotation.AllowCodeBetweenLines",
             "com.google.errorprone.refaster.annotation.Matches",
@@ -416,6 +417,11 @@ public class RefasterTemplateProcessor extends TypeAwareProcessor {
                         embedOptions.add("SHORTEN_NAMES");
                         if (simplifyBooleans(descriptor.afterTemplate.method)) {
                             embedOptions.add("SIMPLIFY_BOOLEANS");
+                        }
+                        List<JCTree.JCAnnotation> useImportPolicyAnnotations = getTemplateAnnotations(descriptor.afterTemplate.method, USE_IMPORT_POLICY::equals);
+                        if (!useImportPolicyAnnotations.isEmpty()) {
+                            // Assume ImportPolicy.STATIC_IMPORT_ALWAYS, as that's all we see in error-prone-support
+                            embedOptions.add("STATIC_IMPORT_ALWAYS");
                         }
 
                         visitMethod.append("                    return embed(\n");

--- a/src/test/java/org/openrewrite/java/template/internal/AbstractRefasterJavaVisitorTest.java
+++ b/src/test/java/org/openrewrite/java/template/internal/AbstractRefasterJavaVisitorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.template.internal;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/java/template/internal/AbstractRefasterJavaVisitorTest.java
+++ b/src/test/java/org/openrewrite/java/template/internal/AbstractRefasterJavaVisitorTest.java
@@ -22,7 +22,8 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor.EmbeddingOption.*;
+import static org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor.EmbeddingOption.SHORTEN_NAMES;
+import static org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor.EmbeddingOption.STATIC_IMPORT_ALWAYS;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
 class AbstractRefasterJavaVisitorTest implements RewriteTest {

--- a/src/test/java/org/openrewrite/java/template/internal/AbstractRefasterJavaVisitorTest.java
+++ b/src/test/java/org/openrewrite/java/template/internal/AbstractRefasterJavaVisitorTest.java
@@ -1,0 +1,65 @@
+package org.openrewrite.java.template.internal;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor.EmbeddingOption.*;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+class AbstractRefasterJavaVisitorTest implements RewriteTest {
+    @Test
+    void useStaticImports() {
+        rewriteRun(
+          spec -> spec.recipe(
+            toRecipe(
+              () -> new AbstractRefasterJavaVisitor() {
+                  private final JavaTemplate template = JavaTemplate
+                    .builder("#{path:any(java.nio.file.Path)}.toFile().exists()")
+                    .build();
+
+                  @Override
+                  public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
+                      JavaTemplate.Matcher matcher;
+                      if ((matcher = template.matcher(getCursor())).find()) {
+                          return embed(
+                            JavaTemplate.apply(
+                              "java.nio.file.Files.exists(#{path:any(java.nio.file.Path)})",
+                              getCursor(),
+                              elem.getCoordinates().replace(),
+                              matcher.parameter(0)
+                            ),
+                            getCursor(),
+                            ctx,
+                            SHORTEN_NAMES, STATIC_IMPORT_ALWAYS
+                          );
+                      }
+                      return super.visitMethodInvocation(elem, ctx);
+                  }
+              }
+            )
+          ),
+          java(
+            "import java.nio.file.Path;\n" +
+              "\n" +
+              "class A {\n" +
+              "    boolean pathExists(Path path) {\n" +
+              "        return path.toFile().exists();\n" +
+              "    }\n" +
+              "}",
+            "import java.nio.file.Path;\n" +
+              "\n" +
+              "import static java.nio.file.Files.exists;\n" +
+              "\n" +
+              "class A {\n" +
+              "    boolean pathExists(Path path) {\n" +
+              "        return exists(path);\n" +
+              "    }\n" +
+              "}"
+          )
+        );
+    }
+}

--- a/src/test/resources/refaster/ShouldAddImportsRecipes.java
+++ b/src/test/resources/refaster/ShouldAddImportsRecipes.java
@@ -291,7 +291,7 @@ public class ShouldAddImportsRecipes extends Recipe {
                                         .build().apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0)),
                                 getCursor(),
                                 ctx,
-                                SHORTEN_NAMES, SIMPLIFY_BOOLEANS
+                                SHORTEN_NAMES, SIMPLIFY_BOOLEANS, STATIC_IMPORT_ALWAYS
                         );
                     }
                     return super.visitMethodInvocation(elem, ctx);


### PR DESCRIPTION
## What's your motivation?
Follow the instructions defined on rules to replace qualified method invocations with static imports.

## Anything in particular you'd like reviewers to focus on?
I've limited this to top level `J.MethodInvocation` only, to cover a common case with as little complexity as possible.
I've also optimistically assumed the goal is to always use static imports when the annotation is used, as per
https://github.com/search?q=repo%3APicnicSupermarket%2Ferror-prone-support+%22%40UseImportPolicy%28%22&type=code

## Have you considered any alternatives or workarounds?
Handling annotation arguments is slightly awkward with assignments, and possible static imports, and not needed for now.
Handling anything beyond direct method invocations comes with a performance penalty as well, that I'd wanted to avoid.

## Any additional context
- Saves us from having `UseStaticImports` twice in https://github.com/openrewrite/rewrite-testing-frameworks/pull/713