### PR TITLE
Fix wildcard type generation in Java 9+

### DIFF
--- a/src/main/java/org/openrewrite/java/template/internal/TemplateCode.java
+++ b/src/main/java/org/openrewrite/java/template/internal/TemplateCode.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.template.internal;
 
+import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
@@ -232,7 +233,13 @@ public class TemplateCode {
             return templateTypeString(elemtype) + "[]";
         } else if (type instanceof Type.WildcardType) {
             Type.WildcardType wildcardType = (Type.WildcardType) type;
-            return wildcardType.toString();
+            if (wildcardType.kind == BoundKind.EXTENDS) {
+                return "? extends " + templateTypeString(wildcardType.type);
+            } else if (wildcardType.kind == BoundKind.SUPER) {
+                return "? super " + templateTypeString(wildcardType.type);
+            } else {
+                return "?";
+            }
         } else {
             if (type.isParameterized()) {
                 return type.tsym.getQualifiedName().toString() + '<' + type.allparams().stream().map(TemplateCode::templateTypeString).collect(joining(", ")) + '>';


### PR DESCRIPTION
## What's changed?
Fix code generated for wildcard types when using Java 9+.

## What's your motivation?
JavaTemplate doesn't support annotated types

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
