### PR TITLE
refactor: Annotate null-checked method parameters with `@Nullable`

### DIFF
--- a/src/main/java/org/openrewrite/java/template/internal/JavacTreeMaker.java
+++ b/src/main/java/org/openrewrite/java/template/internal/JavacTreeMaker.java
@@ -166,7 +166,7 @@ public class JavacTreeMaker {
             }
         }
 
-        public static TypeTag typeTag(Type t) {
+        public static TypeTag typeTag(@Nullable Type t) {
             if (t == null) {
                 return Javac.CTC_VOID;
             }

--- a/src/main/java/org/openrewrite/java/template/internal/Permit.java
+++ b/src/main/java/org/openrewrite/java/template/internal/Permit.java
@@ -113,7 +113,7 @@ public final class Permit {
         return !"false".equals(System.getProperty("lombok.debug.reflection", "false"));
     }
 
-    public static void handleReflectionDebug(Throwable t, Throwable initError) {
+    public static void handleReflectionDebug(Throwable t, @Nullable Throwable initError) {
         if (!isDebugReflection()) {
             return;
         }
@@ -262,7 +262,7 @@ public final class Permit {
         }
     }
 
-    public static void reportReflectionProblem(Throwable initError, String msg) {
+    public static void reportReflectionProblem(@Nullable Throwable initError, String msg) {
         if (!isDebugReflection()) {
             return;
         }
@@ -273,7 +273,7 @@ public final class Permit {
         }
     }
 
-    public static RuntimeException sneakyThrow(Throwable t) {
+    public static RuntimeException sneakyThrow(@Nullable Throwable t) {
         if (t == null) {
             throw new NullPointerException("t");
         }

--- a/src/main/java/org/openrewrite/java/template/internal/TreeMirrorMaker.java
+++ b/src/main/java/org/openrewrite/java/template/internal/TreeMirrorMaker.java
@@ -29,6 +29,7 @@ import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.tree.TreeCopier;
 import com.sun.tools.javac.tree.TreeScanner;
 import com.sun.tools.javac.util.List;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.java.template.internal.JavacTreeMaker.TypeTag;
 
 import java.util.Collections;
@@ -70,7 +71,7 @@ public class TreeMirrorMaker extends TreeCopier<Void> {
     }
 
     @Override
-    public <T extends JCTree> List<T> copy(List<T> originals) {
+    public <T extends JCTree> List<T> copy(@Nullable List<T> originals) {
         List<T> copies = super.copy(originals);
         if (originals != null) {
             Iterator<T> it1 = originals.iterator();
@@ -83,7 +84,7 @@ public class TreeMirrorMaker extends TreeCopier<Void> {
     }
 
     @Override
-    public <T extends JCTree> List<T> copy(List<T> originals, Void p) {
+    public <T extends JCTree> List<T> copy(@Nullable List<T> originals, Void p) {
         List<T> copies = super.copy(originals, p);
         if (originals != null) {
             Iterator<T> it1 = originals.iterator();


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.staticanalysis.AnnotateNullableParameters?organizationId=ODQ2MGExMTUtNDg0My00N2EwLTgzMGMtNGE1NGExMTBmZDkw