### PR TITLE
Detect transitive jar names through chain of interfaces

### DIFF
--- a/src/test/java/org/openrewrite/java/template/internal/ClasspathJarNameDetectorTest.java
+++ b/src/test/java/org/openrewrite/java/template/internal/ClasspathJarNameDetectorTest.java
@@ -113,6 +113,23 @@ class ClasspathJarNameDetectorTest {
         assertThat(jarNames).containsExactly("rewrite-java-8", "rewrite-core-8");
     }
 
+    @Test
+    void detectTransitiveDependencyThroughInterfaces() throws IOException {
+        JCCompilationUnit compilationUnit = compile("""
+          import org.openrewrite.java.tree.Statement;
+          class TestClass {
+              void testMethod(Statement statement) {
+                  statement.getCoordinates(); // extends J, which extends Tree
+              }
+          }
+          """);
+
+        Set<String> jarNames = classpathForTree(firstStatement(compilationUnit));
+
+        // JavaVisitor from rewrite-java extends TreeVisitor from rewrite-core, both are needed
+        assertThat(jarNames).containsExactly("rewrite-java-8", "rewrite-core-8");
+    }
+
     private static JCTree.JCStatement firstStatement(JCCompilationUnit compilationUnit) {
         // Just the first statement of the method body, not the complete compilation unit, just like the processor does
         JCTree.JCClassDecl classDecl = (JCTree.JCClassDecl) compilationUnit.getTypeDecls().getFirst();


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
