### PR TITLE
Adding test dependency of junit-platform-launcher

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,6 +109,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.13.3")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.13.3")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.13.3")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 // Configure main source compilation for Java 8


### PR DESCRIPTION
## What's changed?

Adding test dependency of junit-platform-launcher

## What's your motivation?

Otherwise CI started failing with:
```
Caused by: org.gradle.api.internal.tasks.testing.RequiresTestFrameworkTestClassProcessor$TestFrameworkNotAvailableException: Failed to load JUnit Platform.  Please ensure that all JUnit Platform dependencies are available on the test's runtime classpath, including the JUnit Platform launcher.
```